### PR TITLE
docs: fix incorrect live website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p>
-  <a href="https://opensourcekigali.rw">🌐 Live Website</a>
+  <a href="https://open-source-kigali-website.vercel.app/">🌐 Live Website</a>
   •
   <a href="https://github.com/opensourcekigali/osk-website/issues">🐛 Report Bug</a>
   •


### PR DESCRIPTION
## Summary

- Fixes the live website link in the README pointing to `https://opensourcekigali.rw` which is incorrect
- Updates it to the correct deployed URL: `https://open-source-kigali-website.vercel.app/`

## Test plan

- [x] Click the live website link in the README and confirm it redirects to the correct deployed frontend

Closes #15