### PR TITLE
docs: update README LinkedIn community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ and reviewed quickly by maintainers.
 | Platform | Link |
 |---|---|
 | Discord | https://discord.com/invite/osk |
-| LinkedIn | https://linkedin.com/company/osk |
+| LinkedIn | https://www.linkedin.com/company/open-source-kigali/?viewAsMember=true |
 | GitHub | https://github.com/opensourcekigali |
 | Email | opensourcekigali@gmail.com |
 


### PR DESCRIPTION
## Summary
- update the outdated LinkedIn community link in README.md
- replace the old OSK LinkedIn URL with the official current community page

## Testing
- verified the new link is present in README.md
- verified the old linkedin.com/company/osk link is removed