### PR TITLE
fix: wire mobile contribute CTA

### DIFF
--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -111,7 +111,12 @@ const logo = showWhiteLogo ? LogoWhite : LogoImage;
           ))}
 
           {/* CTA button (mobile) */}
-          <PrimaryButton to="">Contribute to OSK</PrimaryButton>
+          <PrimaryButton
+            to="/membersform"
+            onClick={() => setMobileOpen(false)}
+          >
+            Contribute to OSK
+          </PrimaryButton>
         </div>
       )}
     </>

--- a/src/components/UI/PrimaryButton.tsx
+++ b/src/components/UI/PrimaryButton.tsx
@@ -6,16 +6,19 @@ type PrimaryButtonProps = {
   children: React.ReactNode;
   icon?: boolean;
   className?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 };
 
 const PrimaryButton = ({
   to,
   children,
   className = "",
+  onClick,
 }: PrimaryButtonProps) => {
   return (
     <NavLink
       to={to}
+      onClick={onClick}
       className={`flex items-center justify-center gap-2 text-sm sm:text-base px-5 py-2.5 md:px-7 md:py-3.5 bg-primary-colour hover:bg-brand-500 hover:scale-95 text-white font-semibold rounded-full transition ${className}`}
     >
       {children}


### PR DESCRIPTION
Fixes #28

## Summary
- routes the mobile "Contribute to OSK" CTA to the existing `/membersform` page
- closes the mobile drawer when that CTA is tapped
- lets `PrimaryButton` accept an optional click handler for this navigation case

## Verification
- `npm run build`
- `git diff --check`

## Note
- `npm run lint` currently fails on pre-existing `react-hooks/set-state-in-effect` errors in `src/hooks/useEvents.ts` and `src/hooks/useProjects.ts`. This PR does not touch those files.
