### PR TITLE
docs: add CONTRIBUTORS.md and link from README

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,8 @@
+# Contributors
+
+Thank you to everyone who has contributed to Open Source Kigali! ??
+
+| Name | GitHub | Role |
+|------|--------|------|
+| Didas Mbarushimana Daniel | [@didas](https://github.com/didas) | Project Founder |
+| Leslie Zhang | [@zqleslie](https://github.com/zqleslie) | README fix + CONTRIBUTORS.md |

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ and open-source enthusiasts of all skill levels.
 
 Please read:
 
+See all contributors → [CONTRIBUTORS.md](./CONTRIBUTORS.md)
+
 ```bash
 CONTRIBUTING.md
 ```


### PR DESCRIPTION
## Summary

Creates CONTRIBUTORS.md with the initial contributor table and links it from the README.

### Changes
- Created CONTRIBUTORS.md with the project founder and my contribution
- Added link to CONTRIBUTORS.md in the Contributing section of README.md`n
Closes #29