### PR TITLE
docs: remove Discord help links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,8 +196,6 @@ src/
 If you’re stuck:
 
 -  GitHub Issues — for bugs & feature discussions
--  Discord #code-review — for code help
--  Discord #general — for anything else
 
 We aim to review all pull requests within **48 hours (weekdays)**.
 


### PR DESCRIPTION
Fixes #27

## Summary
- removes the two Discord help-channel references from `CONTRIBUTING.md`
- keeps the GitHub Issues help line in place

## Verification
- `rg -n "Discord|GitHub Issues|Where to Get Help" CONTRIBUTING.md`
- `git diff --check`
