### PR TITLE
fix: link homepage CTA to open issues

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -798,7 +798,14 @@ const HomePage = () => {
                   className="group-hover:translate-x-0.5 transition-transform"
                 />
               </PrimaryButton>
-              <SecondaryButton to="">View Open Issues</SecondaryButton>
+              <a
+                href="https://github.com/Open-Source-Kigali/osk-frontend/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 text-sm sm:text-base px-5 py-2.5 md:px-7 md:py-3 bg-transparent hover:bg-primary-colour text-blue-500 hover:text-white border border-blue-500 hover:scale-95 font-semibold rounded-full transition"
+              >
+                View Open Issues
+              </a>
             </div>
 
             {/* Stat pills — from CTA_STATS constant */}


### PR DESCRIPTION
Closes #35

Fix the empty homepage CTA link by pointing **View Open Issues** to the repository issues page in a new tab while keeping the existing button styling.

## Verification

- `npm ci`
- `npm run build`