### PR TITLE
docs: remove Discord links from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,8 +196,6 @@ src/
 If you’re stuck:
 
 -  GitHub Issues — for bugs & feature discussions
--  Discord #code-review — for code help
--  Discord #general — for anything else
 
 We aim to review all pull requests within **48 hours (weekdays)**.
 


### PR DESCRIPTION
## Summary
- Removed Discord #code-review and #general links from "Where to Get Help" section
- OSK does not currently have a Discord server, so these links are misleading

## Changes
- `CONTRIBUTING.md`: Removed two Discord channel references

Fixes #27