### PR TITLE
Fix LinkedIn link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ and reviewed quickly by maintainers.
 | Platform | Link                                             |
 | -------- | ------------------------------------------------ |
 | Discord  | https://discord.com/invite/3dTFZSn6Tq/invite/osk |
-| LinkedIn | https://linkedin.com/company/osk                 |
+| LinkedIn | |https://www.linkedin.com/company/open-source-kigali/?viewAsMember=true |
 | GitHub   | https://github.com/open-source-kigali            |
 | Email    | opensourcekigali@gmail.com                       |
 


### PR DESCRIPTION
Updated LinkedIn link to the correct URL.
 updated the LinkedIn URL in README.md
the old link was incorrect
issue #18
