### PR TITLE
feat: add back to top button on long pages 

### DIFF
--- a/src/components/UI/BackToTop.tsx
+++ b/src/components/UI/BackToTop.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ChevronUp } from "lucide-react";
+import { useScrolled } from "../../hooks/useScrolled";
+
+const BackToTop = () => {
+  const scrolled = useScrolled(400);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!scrolled) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-6 right-6 p-3 bg-primary-colour hover:bg-brand-500 text-white rounded-full shadow-lg transition-transform hover:scale-110 z-50 flex items-center justify-center"
+      aria-label="Back to top"
+    >
+      <ChevronUp size={24} />
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/src/pages/RootLayer.tsx
+++ b/src/pages/RootLayer.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import { Outlet, useLocation } from "react-router"
 import MainNavigation from "../components/MainNavigation"
 import Footer from "../components/Footer"
+import BackToTop from "../components/UI/BackToTop"
 
 const RootLayer = () => {
   const location = useLocation()
@@ -16,6 +17,7 @@ const RootLayer = () => {
       <main key={location.pathname} className="page-fade">
         <Outlet />
       </main>
+      <BackToTop />
       <Footer />
     </>
   )


### PR DESCRIPTION
## What does this PR do?

Adds a "Back to Top" button that appears in the bottom right corner after scrolling down 400px. Clicking it smoothly scrolls the user back to the top of the page.

## Related issue

Closes #11

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] Tested locally in the browser
- [x] No `console.log` statements left in the code

## Screenshots (if UI change)

*(I don't have a screenshot right now, but feel free to add one if you'd like!)*

## Notes for the reviewer

The component uses the existing `useScrolled` hook and `lucide-react` for the icon. It has been added to `RootLayer.tsx` so it applies globally.
