### PR TITLE
fix: smooth scroll to anchor links on the partners page

### DIFF
--- a/src/components/UI/PrimaryButton.tsx
+++ b/src/components/UI/PrimaryButton.tsx
@@ -12,10 +12,11 @@ const PrimaryButton = ({
   children,
   className = "",
 }: PrimaryButtonProps) => {
+  const isExternal = to.startsWith("http");
   return (
     <a
-      target="_blank"
-      rel="noopener noreferrer"
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
       href={to}
       className={`flex items-center justify-center gap-2 text-sm sm:text-base px-5 py-2.5 md:px-7 md:py-3.5 bg-primary-colour hover:bg-brand-500 hover:scale-95 text-white font-semibold rounded-full transition ${className}`}
     >

--- a/src/pages/Partners.tsx
+++ b/src/pages/Partners.tsx
@@ -48,7 +48,7 @@ const Partners = () => (
           hubs to grow Rwanda's open-source ecosystem and build software that matters.
         </p>
         <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <PrimaryButton to="/partnersform">
+          <PrimaryButton to="#become">
             Become a Partner
           </PrimaryButton>
           
@@ -94,7 +94,7 @@ const Partners = () => (
             <strong className="text-gray-900">{PARTNERS.length} organisations</strong>{" "}
             across Rwanda and we're actively looking for more.
           </p>
-          <PrimaryButton to="/partnersform" className="md:w-1/2">
+          <PrimaryButton to="#become" className="md:w-1/2">
             Partner with Us
           </PrimaryButton>
         </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the "Become a Partner" CTA to link to the `#become` anchor and smoothly scroll to the form section. Additionally, the `PrimaryButton` component was updated to only use `target="_blank"` for external HTTP links so that internal anchors work properly.

## Related issue

Closes #12

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] Tested locally in the browser
- [x] No `console.log` statements left in the code
