### PR TITLE
docs: make email address in CODE_OF_CONDUCT.md clickable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ We are committed to making participation in this project a **harassment-free exp
 
 If you experience or witness a violation of this Code of Conduct, you can report it to the OSK leadership team:
 
- **opensourcekigali@gmail.com**
+ **[opensourcekigali@gmail.com](mailto:opensourcekigali@gmail.com)**
 
 All reports will be treated seriously, reviewed promptly, and kept confidential.
 


### PR DESCRIPTION
## What does this PR do?

Updates the contact email address in the Enforcement section of `CODE_OF_CONDUCT.md` to be a clickable `mailto:` link, making it easier for users to report violations.

## Related issue

Closes #24

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] Tested locally in the browser
- [x] No `console.log` statements left in the code
