### PR TITLE
feat: remove Discord channels section from Community page

### DIFF
--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -5,64 +5,7 @@ export const COMMUNITY_STATS = [
   { value: "4", label: "Live projects", sub: "open to contribute" },
 ];
 
-export const CHANNELS = [
-  {
-    name: "general",
-    emoji: "💬",
-    desc: "Day-to-day talk, intros, memes, everything.",
-    members: 98,
-    active: true,
-  },
-  {
-    name: "code-review",
-    emoji: "🔍",
-    desc: "Post your PRs. Get honest, helpful feedback.",
-    members: 74,
-    active: true,
-  },
-  {
-    name: "good-first-issues",
-    emoji: "🟢",
-    desc: "Curated issues for people just getting started.",
-    members: 61,
-    active: false,
-  },
-  {
-    name: "opportunities",
-    emoji: "📌",
-    desc: "Jobs, internships, grants, and collabs shared here first.",
-    members: 89,
-    active: true,
-  },
-  {
-    name: "project-updates",
-    emoji: "📦",
-    desc: "Maintainers post progress. Contributors stay in the loop.",
-    members: 55,
-    active: false,
-  },
-  {
-    name: "design-collab",
-    emoji: "🎨",
-    desc: "Figma links, UI feedback, design systems discussions.",
-    members: 42,
-    active: false,
-  },
-  {
-    name: "events",
-    emoji: "📅",
-    desc: "Hackathons, meetups, workshops — everything calendar-worthy.",
-    members: 77,
-    active: true,
-  },
-  {
-    name: "off-topic",
-    emoji: "☕",
-    desc: "Because not everything has to be about code.",
-    members: 93,
-    active: false,
-  },
-];
+
 
 export const GUIDELINES = [
   { rule: "Respect everyone, always. Experience level is not a ranking." },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,7 +6,6 @@ export { NAV_LINKS, FOOTER_LINKS } from "./navigation";
 export { ABOUT_STATS, STORY_POINTS, VALUES, ABOUT_TEAM } from "./about";
 export {
   COMMUNITY_STATS,
-  CHANNELS,
   GUIDELINES,
   SOCIAL_PLATFORMS,
 } from "./community";


### PR DESCRIPTION
## What does this PR do?

Completes the removal of the Discord channels grid from the Community page by deleting the unused `CHANNELS` array from `src/constants/community.ts` and removing its export from `src/constants/index.ts`.

## Related issue

Closes #42

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] Tested locally in the browser
- [x] No `console.log` statements left in the code
