### PR TITLE
changes the discord icon & link to the whatsapp icon & link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,9 @@
 import { NavLink } from "react-router";
 import whiteLogo from "@/assets/Logo/OSK-primary-logo-1200-400-white.svg";
 
-import { MessageCircle, Mail } from "lucide-react";
+import { Mail } from "lucide-react";
 import { FiGithub, FiTwitter, FiLinkedin } from "react-icons/fi";
+import { FaWhatsapp } from "react-icons/fa";
 
 interface FooterLinkGroup {
   heading: string;
@@ -78,8 +79,8 @@ const socialLinks = [
     label: "LinkedIn",
   },
   {
-    icon: <MessageCircle size={18} />,
-    href: "https://discord.com/invite/3dTFZSn6Tq",
+    icon: <FaWhatsapp size={18} />,
+    href: "https://chat.whatsapp.com/GimdjJcYLyyG62zpgsI0zB",
     label: "Discord",
   },
   {


### PR DESCRIPTION
## What does this PR do?

Replace the discord icon and social link to the ones of Whatsapp using the OSK whatsapp community link and the FAwhatsapp installed icon through importing it from react/icons

## Related issue

Closes #46

## Type of change

- [ ] Bug fix
- [✅ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [✅ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [ ] No `console.log` statements left in the code

## Screenshots (if UI change)

before image 
<img width="411" height="320" alt="image" src="https://github.com/user-attachments/assets/748032d1-ba61-424b-8f56-c07f5bda5db7" />

after image <img width="586" height="490" alt="image" src="https://github.com/user-attachments/assets/e568a42e-3e6f-4f2e-b9bd-ea56e6ca1037" />

## Notes for the reviewer

None.