### PR TITLE
feat: add scroll animations to sections across the website

### DIFF
--- a/src/components/UI/ScrollAnimatedItem.tsx
+++ b/src/components/UI/ScrollAnimatedItem.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useScrollAnimation } from "@/hooks";
+
+interface Props {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}
+
+export const ScrollAnimatedItem: React.FC<Props> = ({ children, delay = 0, className = "" }) => {
+  const ref = useScrollAnimation();
+  return (
+    <div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      className={`opacity-0 ${className}`}
+      style={delay ? { animationDelay: `${delay}s` } : {}}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/UI/ScrollAnimatedItem.tsx
+++ b/src/components/UI/ScrollAnimatedItem.tsx
@@ -1,17 +1,17 @@
-import React from "react";
+import type { ReactNode, FC, RefObject } from "react";
 import { useScrollAnimation } from "@/hooks";
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
   delay?: number;
   className?: string;
 }
 
-export const ScrollAnimatedItem: React.FC<Props> = ({ children, delay = 0, className = "" }) => {
+export const ScrollAnimatedItem: FC<Props> = ({ children, delay = 0, className = "" }) => {
   const ref = useScrollAnimation();
   return (
     <div
-      ref={ref as React.RefObject<HTMLDivElement>}
+      ref={ref as RefObject<HTMLDivElement>}
       className={`opacity-0 ${className}`}
       style={delay ? { animationDelay: `${delay}s` } : {}}
     >

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useForm } from "./useForm";
 export { useLocalStorage } from "./useLocalStorage";
 export { useProjects } from "./useProjects";
 export { useEvents } from "./useEvents";
+export { useScrollAnimation } from "./useScrollAnimation";

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -15,7 +15,6 @@ export function useEvents(): UseEventsReturn {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     fetchEvents()
       .then((data) => {
         if (!cancelled) {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -15,7 +15,6 @@ export function useProjects(): UseProjectsReturn {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     fetchProjects()
       .then((data) => {
         if (!cancelled) {

--- a/src/hooks/useScrollAnimation.ts
+++ b/src/hooks/useScrollAnimation.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+export const useScrollAnimation = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("animate-fade-up");
+          entry.target.classList.remove("opacity-0");
+          observer.unobserve(entry.target);
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    if (ref.current) observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return ref;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,13 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
 @keyframes page-fade-in {
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -31,5 +38,10 @@ html {
   --color-text-diabled:#d1d5db;
   --color-background-colour:#0a0f1e;
 
+  --animate-fade-up: fadeUp 0.6s ease forwards;
+  @keyframes fadeUp {
+    0% { opacity: 0; transform: translateY(24px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
 }
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -12,6 +12,7 @@ import groupImg from "@/assets/images/did.jpeg.jpeg";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
 import PrimaryButton from "@/components/UI/PrimaryButton";
 import SecondaryButton from "@/components/UI/SecondaryButton";
+import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 //Types
 interface DotProps {
@@ -152,8 +153,8 @@ const About = () => (
 
         {/* Right — numbered story points from constant */}
         <div className="flex flex-col divide-y divide-gray-100">
-          {STORY_POINTS.map((sp) => (
-            <div key={sp.number} className="py-6 first:pt-0 last:pb-0">
+          {STORY_POINTS.map((sp, idx) => (
+            <ScrollAnimatedItem key={sp.number} delay={idx * 0.15} className="py-6 first:pt-0 last:pb-0">
               <div className="flex gap-4">
                 <span className="text-blue-500 font-black text-base w-8 shrink-0">
                   {sp.number}.
@@ -167,7 +168,7 @@ const About = () => (
                   </p>
                 </div>
               </div>
-            </div>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>
@@ -237,9 +238,10 @@ const About = () => (
 
         {/* Values list — data from VALUES constant */}
         <div className="divide-y divide-gray-100">
-          {VALUES.map((v) => (
-            <div
+          {VALUES.map((v, idx) => (
+            <ScrollAnimatedItem
               key={v.number}
+              delay={idx * 0.15}
               className="group py-8 grid grid-cols-12 gap-6 items-start hover:bg-gray-50 hover:-mx-6 hover:px-6 rounded-xl transition-all duration-200 cursor-default"
             >
               <span className="col-span-2 md:col-span-1 text-gray-200 font-black text-2xl group-hover:text-blue-500 transition-colors font-mono">
@@ -253,7 +255,7 @@ const About = () => (
                   {v.body}
                 </p>
               </div>
-            </div>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>
@@ -277,7 +279,7 @@ const About = () => (
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {ABOUT_TEAM.map((m) => {
+          {ABOUT_TEAM.map((m, idx) => {
             // Build only the social links that are not null
             const socialLinks = [
               m.links.linkedin && {
@@ -317,8 +319,9 @@ const About = () => (
             }[];
 
             return (
-              <div
+              <ScrollAnimatedItem
                 key={m.initials}
+                delay={idx * 0.15}
                 className="bg-white rounded-2xl overflow-hidden border border-gray-100 hover:shadow-md transition-shadow duration-200"
               >
                 {/* Avatar area */}
@@ -371,7 +374,7 @@ const About = () => (
                     </div>
                   )}
                 </div>
-              </div>
+              </ScrollAnimatedItem>
             );
           })}
         </div>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -9,6 +9,7 @@ import {
 import { COMMUNITY_STATS, GUIDELINES, SOCIAL_PLATFORMS } from "@/constants";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
 import PrimaryButton from "@/components/UI/PrimaryButton";
+import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 const SOCIAL_ICONS: Record<string, React.ReactNode> = {
   discord: <MessageCircle size={22} />,
@@ -137,14 +138,14 @@ const Community = () => (
 
         {/* Social platforms — from SOCIAL_PLATFORMS constant */}
         <div className="mt-14 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
-          {SOCIAL_PLATFORMS.map((p) => (
-            <a
-              key={p.name}
-              href={p.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex items-start gap-4 p-5 rounded-2xl bg-gray-50 hover:bg-white hover:shadow-md border border-transparent hover:border-gray-100 transition-all duration-300"
-            >
+          {SOCIAL_PLATFORMS.map((p, idx) => (
+            <ScrollAnimatedItem key={p.name} delay={idx * 0.15}>
+              <a
+                href={p.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-start gap-4 p-5 rounded-2xl bg-gray-50 hover:bg-white hover:shadow-md border border-transparent hover:border-gray-100 transition-all duration-300"
+              >
               <div
                 className={`w-11 h-11 rounded-xl flex items-center justify-center text-white shrink-0 shadow-sm group-hover:scale-105 transition-transform ${p.color}`}
               >
@@ -165,7 +166,8 @@ const Community = () => (
                 </p>
                 <p className="text-gray-400 text-xs leading-snug">{p.desc}</p>
               </div>
-            </a>
+              </a>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>
@@ -199,15 +201,16 @@ const Community = () => (
         {/* Right: rules — from GUIDELINES constant */}
         <div className="space-y-3">
           {GUIDELINES.map((g, i) => (
-            <div
+            <ScrollAnimatedItem
               key={i}
+              delay={i * 0.15}
               className="flex items-start gap-4 bg-white/5 border border-white/10 rounded-xl px-5 py-4 hover:bg-white/8 transition-colors duration-200"
             >
               <span className="text-gray-600 font-mono text-sm shrink-0 mt-0.5">
                 {String(i + 1).padStart(2, "0")}
               </span>
               <p className="text-gray-300 text-sm leading-relaxed">{g.rule}</p>
-            </div>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -29,6 +29,7 @@ import {
 import type { HomeEventType, ActivityIconKey } from "@/constants";
 import PartnersMarquee from "@/components/UI/PartnersMarquee";
 import { Loader } from "@/components/UI";
+import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 // ── Assets
 import heroImage from "@/assets/images/HeroImage.jpeg";
@@ -175,8 +176,9 @@ const HomePage = () => {
           {/* Stats — from HERO_STATS constant */}
           <div className="flex flex-wrap justify-center md:justify-start items-center gap-6 md:gap-16 mt-16 pt-6">
             {HERO_STATS.map((stat, index) => (
-              <div
+              <ScrollAnimatedItem
                 key={stat.label}
+                delay={index * 0.15}
                 className={`flex-1 min-w-20 py-4 ${
                   index !== HERO_STATS.length - 1
                     ? "md:border-r border-gray-300"
@@ -189,7 +191,7 @@ const HomePage = () => {
                 <p className="text-sm sm:text-base md:text-lg text-primary-colour font-medium mt-1">
                   {stat.label}
                 </p>
-              </div>
+              </ScrollAnimatedItem>
             ))}
           </div>
         </div>
@@ -199,7 +201,7 @@ const HomePage = () => {
 
       {/* ABOUT STRIP */}
       <section className="py-16 md:py-28 px-4 md:px-20 bg-white">
-        <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-8">
+        <ScrollAnimatedItem className="max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-8">
           {/* Left */}
           <div className="w-full md:w-1/2">
             <EyebrowLabel text="About Us" align="left" className="mb-4" />
@@ -222,7 +224,7 @@ const HomePage = () => {
               className="w-full rounded-lg object-cover"
             />
           </div>
-        </div>
+        </ScrollAnimatedItem>
       </section>
 
       {/* FEATURED PROJECTS */}
@@ -293,9 +295,10 @@ const HomePage = () => {
           {/* Other projects grid — remaining 3 */}
           {!projectsLoading && !projectsError && (
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-              {homeProjects.slice(1).map((project) => (
-                <div
+              {homeProjects.slice(1).map((project, idx) => (
+                <ScrollAnimatedItem
                   key={project.id}
+                  delay={idx * 0.15}
                   className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden flex flex-col hover:shadow-lg transition-shadow duration-300"
                 >
                   <div className="h-48 w-full overflow-hidden">
@@ -328,7 +331,7 @@ const HomePage = () => {
                       </SecondaryButton>
                     </div>
                   </div>
-                </div>
+                </ScrollAnimatedItem>
               ))}
             </div>
           )}
@@ -564,9 +567,10 @@ const HomePage = () => {
           {/* Other events grid */}
           {!eventsLoading && !eventsError && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {restHomeEvents.map((event) => (
-                <div
+              {restHomeEvents.map((event, idx) => (
+                <ScrollAnimatedItem
                   key={event.id}
+                  delay={idx * 0.15}
                   className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden flex flex-col hover:shadow-md transition-shadow"
                 >
                   {event.coverImage && (
@@ -611,7 +615,7 @@ const HomePage = () => {
                       RSVP →
                     </NavLink>
                   </div>
-                </div>
+                </ScrollAnimatedItem>
               ))}
             </div>
           )}
@@ -639,8 +643,9 @@ const HomePage = () => {
             onMouseLeave={() => setPaused(false)}
           >
             {visibleTestimonials.map((t, i) => (
-              <div
+              <ScrollAnimatedItem
                 key={`${t.id}-${current}-${i}`}
+                delay={i * 0.15}
                 className={`bg-gray-50 rounded-2xl p-6 sm:p-8 flex flex-col gap-4 ${
                   i === 0
                     ? "flex"
@@ -665,7 +670,7 @@ const HomePage = () => {
                     <p className="text-gray-400 text-xs">{t.role}</p>
                   </div>
                 </div>
-              </div>
+              </ScrollAnimatedItem>
             ))}
           </div>
 

--- a/src/pages/Partners.tsx
+++ b/src/pages/Partners.tsx
@@ -5,6 +5,7 @@ import EyebrowLabel from "../components/UI/EyebrowLable";
 import PartnerMarquee from '@/components/UI/PartnersMarquee';
 import PrimaryButton from "@/components/UI/PrimaryButton";
 import SecondaryButton from "@/components/UI/SecondaryButton";
+import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 
 // Icon map for benefits — keeps PARTNER_BENEFITS JSX-free in constants
@@ -131,11 +132,11 @@ const Partners = () => (
               border: "border-rose-100",
             },
           ].map((item, i) => (
-            <div key={i} className={`${item.bg} border ${item.border} rounded-2xl p-6`}>
+            <ScrollAnimatedItem key={i} delay={i * 0.15} className={`${item.bg} border ${item.border} rounded-2xl p-6`}>
               <div className="mb-3">{item.icon}</div>
               <p className="text-3xl font-black text-gray-900 mb-1">{item.count}</p>
               <p className="text-sm font-semibold text-gray-600">{item.label}</p>
-            </div>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>
@@ -184,8 +185,9 @@ const Partners = () => (
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {PARTNER_BENEFITS.map((b, i) => (
-            <div
+            <ScrollAnimatedItem
               key={i}
+              delay={i * 0.15}
               className="border border-gray-100 rounded-2xl p-6 hover:border-gray-200 hover:shadow-sm transition-all"
             >
               <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${b.iconBg} ${b.iconColor} mb-4`}>
@@ -193,7 +195,7 @@ const Partners = () => (
               </div>
               <h3 className="text-base font-black text-gray-900 mb-2">{b.title}</h3>
               <p className="text-gray-500 text-sm leading-relaxed">{b.body}</p>
-            </div>
+            </ScrollAnimatedItem>
           ))}
         </div>
       </div>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -21,6 +21,7 @@ import { useFilter, useProjects } from "@/hooks";
 import { GOOD_FIRST_ISSUES } from "@/constants";
 import type { Projects, Issue, ProjectStatus, ProjectCategory } from "@/types";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
+import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 // ─── Meta maps
 const STATUS_META: Record<
@@ -530,8 +531,10 @@ const Projectt = () => {
 
               {nonFeatured.length > 0 ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-                  {nonFeatured.map((p) => (
-                    <ProjectCard key={p.id} project={p} />
+                  {nonFeatured.map((p, idx) => (
+                    <ScrollAnimatedItem key={p.id} delay={idx * 0.15}>
+                      <ProjectCard project={p} />
+                    </ScrollAnimatedItem>
                   ))}
                 </div>
               ) : (


### PR DESCRIPTION
## Description
This PR addresses the lack of scroll animations across the website to make the site feel more dynamic and polished, as requested in #41. It introduces subtle fade-in and slide-up animations that trigger when sections scroll into view.

Fixes #41 

## What was done
- Added custom `@keyframes fadeUp` and `--animate-fade-up` configuration to `src/index.css`.
- Added a `@media (prefers-reduced-motion: reduce)` block to `src/index.css` to respect users' accessibility settings.
- Created `useScrollAnimation` hook using the `IntersectionObserver` API.
- Created a `ScrollAnimatedItem` wrapper component to handle staggered entrance animations easily.
- Applied staggered animations to cards and sections across `HomePage.tsx`, `About.tsx`, `Projects.tsx`, `Community.tsx`, and `Partners.tsx`.

## Acceptance Criteria Met
- [x] Custom animation is added to global CSS config
- [x] `useScrollAnimation` hook is created and exported
- [x] Sections animate in when they scroll into view
- [x] Cards stagger when animating in groups
- [x] Animations respect `prefers-reduced-motion`
- [x] No extra npm packages were added
