### PR TITLE
fix: remove unused React import in BackToTop

### DIFF
--- a/src/components/UI/BackToTop.tsx
+++ b/src/components/UI/BackToTop.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ChevronUp } from "lucide-react";
 import { useScrolled } from "../../hooks/useScrolled";
 


### PR DESCRIPTION
## What does this PR do?

Removes the unused `import React from "react";` in `BackToTop.tsx` to fix the CI pipeline failure (TS6133).

## Related issue

<!-- Leave this blank if there is no specific issue number -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Tested locally in the browser
- [x] New data is in `src/constants/`, not hardcoded in a component
- [x] No `console.log` statements left in the code

## Screenshots (if UI change)

N/A

## Notes for the reviewer

The CI pipeline should now pass successfully as the unused import has been removed.
