### PR TITLE
chore: fix global lint errors in hooks to unblock CI/CD pipeline

### DIFF
--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -15,7 +15,6 @@ export function useEvents(): UseEventsReturn {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     fetchEvents()
       .then((data) => {
         if (!cancelled) {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -15,7 +15,6 @@ export function useProjects(): UseProjectsReturn {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     fetchProjects()
       .then((data) => {
         if (!cancelled) {


### PR DESCRIPTION
## What does this PR do?
This PR resolves the `react-hooks/set-state-in-effect` ESLint errors inside `useProjects.ts` and `useEvents.ts` that were previously causing the `npm run lint` command (and the automated CI/CD pipeline) to fail for the entire repository. The pipeline is now completely green and unblocked.

## Type of change
- [x] Bug fix
- [x] Refactor (no behaviour change)
