### PR TITLE
fix: view all issues button on the homepage fixed to open in new tab …

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -871,7 +871,14 @@ const HomePage = () => {
                   className="group-hover:translate-x-0.5 transition-transform"
                 />
               </PrimaryButton>
-              <SecondaryButton to="">View Open Issues</SecondaryButton>
+              <a 
+                href="https://github.com/Open-Source-Kigali/osk-frontend/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 text-sm sm:text-base px-5 py-2.5 md:px-7 md:py-3 bg-transparent hover:bg-primary-colour text-blue-500 hover:text-white border border-blue-500 hover:scale-95 font-semibold rounded-full transition"
+              >
+                View Open Issues
+              </a>
             </div>
 
             {/* Stat pills — from CTA_STATS constant */}


### PR DESCRIPTION
…and correct link

## What does this PR do?

fix: the View open issues button on homepage did nothing but was fixed with the correct link and opens in a new tab

## Related issue

Closes #39

## Type of change

- [ ✅] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [ ] No `console.log` statements left in the code

## Screenshots (if UI change)

no UI changes

## Notes for the reviewer

I didn't use the secondarybutton component because would require for me to change the component to fit the other attributes that are not there like the target and rel