### PR TITLE
fix: remove em dashes from site text

### DIFF
--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -24,10 +24,10 @@ function transform(p: ApiProject): Projects {
       forks:        p.ghForks,
     },
     featured:     p.featured,
-    language:     p.ghLanguage ?? "—",
+    language:     p.ghLanguage ?? "-",
     langColor:    p.langColor ?? "#9ca3af",
     lastActivity: formatRelativeTime(p.ghPushedAt),
-    maintainer:   p.maintainer ?? "—",
+    maintainer:   p.maintainer ?? "-",
     repoUrl:      `https://github.com/${p.repoOwner}/${p.repoName}`,
     createdAt:    p.createdAt,
   };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -108,7 +108,7 @@ const Footer = () => {
               />
             </NavLink>
             <p className="text-sm leading-relaxed text-gray-500">
-              Building Rwanda's open source ecosystem — one contribution at a
+              Building Rwanda's open source ecosystem - one contribution at a
               time.
             </p>
             {/* Socials */}

--- a/src/components/UI/PartnersMarquee.tsx
+++ b/src/components/UI/PartnersMarquee.tsx
@@ -2,7 +2,7 @@ import { MARQUEE_PARTNERS } from "@/constants";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 
-// How fast the marquee scrolls — higher = slower
+// How fast the marquee scrolls - higher = slower
 const MARQUEE_DURATION = "30s";
 
 // Tripling the array for seamless loop

--- a/src/constants/about.ts
+++ b/src/constants/about.ts
@@ -17,7 +17,7 @@ export const STORY_POINTS = [
   {
     number: "01",
     title: "6 years of intense research",
-    body: "Rwanda has real talent. The gap was never skill — it was access to mentors, meaningful projects, and a community that made contribution feel possible.",
+    body: "Rwanda has real talent. The gap was never skill - it was access to mentors, meaningful projects, and a community that made contribution feel possible.",
   },
   {
     number: "02",
@@ -50,7 +50,7 @@ export const VALUES = [
   {
     number: "04",
     title: "Consistency over Hype",
-    body: "We show up every week, not just when it's exciting. The Wednesday sessions, the code reviews, the slow PRs — that's where the real growth happens.",
+    body: "We show up every week, not just when it's exciting. The Wednesday sessions, the code reviews, the slow PRs - that's where the real growth happens.",
   },
   {
     number: "05",

--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -51,7 +51,7 @@ export const CHANNELS = [
   {
     name: "events",
     emoji: "📅",
-    desc: "Hackathons, meetups, workshops — everything calendar-worthy.",
+    desc: "Hackathons, meetups, workshops - everything calendar-worthy.",
     members: 77,
     active: true,
   },
@@ -69,7 +69,7 @@ export const GUIDELINES = [
   { rule: "Ask dumb questions. There are no dumb questions in #general." },
   { rule: "Give feedback on code, not people. Be direct, not unkind." },
   {
-    rule: "Share opportunities. If it's good for you, share it — someone else needs it too.",
+    rule: "Share opportunities. If it's good for you, share it - someone else needs it too.",
   },
   {
     rule: "Show up. You don't have to be perfect, but you have to be present.",
@@ -77,7 +77,7 @@ export const GUIDELINES = [
   { rule: "Violations of safety or respect get you removed. No negotiation." },
 ];
 
-// Social platforms — icon is injected in the component to keep this file JSX-free
+// Social platforms - icon is injected in the component to keep this file JSX-free
 export const SOCIAL_PLATFORMS = [
   {
     name: "Discord",

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -7,7 +7,7 @@ export const EVENTS: OSKEvent[] = [
     type: "hackathon",
     status: "upcoming",
     mode: "in-person",
-    title: "OSK Build Challenge — Q3 2025",
+    title: "OSK Build Challenge - Q3 2025",
     tagline: "48 hours. Real problems. Real code.",
     description:
       "Our biggest event of the year. Teams of 2–5 tackle real societal challenges in Rwanda using open-source tools. Mentors on standby. Cash prizes for the top three teams.",
@@ -22,7 +22,7 @@ export const EVENTS: OSKEvent[] = [
     capacity: 120,
     speakers: [
       { name: "Didas Mbarushimana", role: "Community Lead", initials: "DD" },
-      { name: "Guest Mentor — TBA", role: "Industry Expert", initials: "GM" },
+      { name: "Guest Mentor - TBA", role: "Industry Expert", initials: "GM" },
     ],
     tags: ["hackathon", "open source", "prizes"],
     featured: true,
@@ -34,7 +34,7 @@ export const EVENTS: OSKEvent[] = [
     type: "session",
     status: "upcoming",
     mode: "virtual",
-    title: "Wednesday Tech Session — APIs & Authentication",
+    title: "Wednesday Tech Session - APIs & Authentication",
     tagline: "Build a secure Node.js API from scratch.",
     description:
       "Live coding session covering REST API design, JWT authentication, and deploying to Vercel. Bring your laptop.",
@@ -44,7 +44,7 @@ export const EVENTS: OSKEvent[] = [
     month: "JUL",
     year: 2025,
     time: "7:00 PM – 8:30 PM",
-    location: "Discord — #tech-session",
+    location: "Discord - #tech-session",
     attendees: 34,
     capacity: null,
     speakers: [{ name: "Tech Lead", role: "OSK Maintainer", initials: "TL" }],
@@ -84,7 +84,7 @@ export const EVENTS: OSKEvent[] = [
     type: "session",
     status: "past",
     mode: "virtual",
-    title: "Wednesday Session — Git Rebase Deep Dive",
+    title: "Wednesday Session - Git Rebase Deep Dive",
     tagline: "Interactive history rewriting with confidence.",
     description:
       "A live walkthrough of git rebase, interactive rebase, and squashing commits on real OSK project history.",

--- a/src/constants/homepage.ts
+++ b/src/constants/homepage.ts
@@ -93,12 +93,12 @@ export const HOME_EVENTS: HomeEvent[] = [
   {
     id: 1,
     type: "hackathon",
-    title: "OSK Quarterly Hackathon — Build for Rwanda",
+    title: "OSK Quarterly Hackathon - Build for Rwanda",
     date: "July 26–27, 2025",
     time: "8:00 AM – 6:00 PM",
     location: "Kigali Innovation City, Rwanda",
     description:
-      "A 48-hour open source build challenge where teams tackle real societal problems. Open to all skill levels — developers, designers, and writers welcome.",
+      "A 48-hour open source build challenge where teams tackle real societal problems. Open to all skill levels - developers, designers, and writers welcome.",
     tag: "Hackathon",
   },
   {
@@ -115,7 +115,7 @@ export const HOME_EVENTS: HomeEvent[] = [
   {
     id: 3,
     type: "meetup",
-    title: "Monthly Community Meetup — July Edition",
+    title: "Monthly Community Meetup - July Edition",
     date: "July 5, 2025",
     time: "3:00 PM – 5:30 PM",
     location: "Norrsken Kigali",
@@ -126,7 +126,7 @@ export const HOME_EVENTS: HomeEvent[] = [
   {
     id: 4,
     type: "session",
-    title: "Weekly Technical Session — Code Review & Contributions",
+    title: "Weekly Technical Session - Code Review & Contributions",
     date: "Every Wednesday",
     time: "7:00 PM – 8:30 PM",
     location: "Virtual (Discord)",
@@ -163,7 +163,7 @@ export const TESTIMONIALS: Testimonial[] = [
     initials: "JH",
     color: "#10b981",
     quote:
-      "I came in knowing very little about collaboration. The weekly sessions and code reviews transformed how I think about software. OSK doesn't just teach you to code — it teaches you to build.",
+      "I came in knowing very little about collaboration. The weekly sessions and code reviews transformed how I think about software. OSK doesn't just teach you to code - it teaches you to build.",
   },
   {
     id: 3,
@@ -231,7 +231,7 @@ export const CTA_ACTIVITY: ActivityItem[] = [
     id: 4,
     iconKey: "event",
     iconBg: "bg-yellow-500",
-    text: "OSK Hackathon Q3 — registration is now open",
+    text: "OSK Hackathon Q3 - registration is now open",
     time: "1 hr ago",
   },
   {
@@ -261,13 +261,13 @@ export const FAQ_ITEMS: FAQItem[] = [
     id: 1,
     question: "Do I need prior experience to join Open Source Kigali?",
     answer:
-      "Not at all. OSK is open to everyone — from complete beginners to seasoned engineers. We have beginner-friendly issues labelled 'Good First Issue', structured onboarding, and mentors who will guide you through your first contribution step by step.",
+      "Not at all. OSK is open to everyone - from complete beginners to seasoned engineers. We have beginner-friendly issues labelled 'Good First Issue', structured onboarding, and mentors who will guide you through your first contribution step by step.",
   },
   {
     id: 2,
     question: "How is OSK different from just learning on YouTube or Udemy?",
     answer:
-      "Passive learning gives you knowledge; OSK gives you experience. You'll work on real projects used by real people, collaborate with a team, get your code reviewed, and build a GitHub profile that shows employers what you can actually do — not just what courses you've completed.",
+      "Passive learning gives you knowledge; OSK gives you experience. You'll work on real projects used by real people, collaborate with a team, get your code reviewed, and build a GitHub profile that shows employers what you can actually do - not just what courses you've completed.",
   },
   {
     id: 3,
@@ -280,7 +280,7 @@ export const FAQ_ITEMS: FAQItem[] = [
     id: 4,
     question: "How much time do I need to commit each week?",
     answer:
-      "There's no hard minimum. Even a few hours a week is enough to make meaningful contributions. We have weekly technical sessions (Wednesday evenings), monthly meetups, and quarterly hackathons — but you can participate at whatever pace works for your schedule.",
+      "There's no hard minimum. Even a few hours a week is enough to make meaningful contributions. We have weekly technical sessions (Wednesday evenings), monthly meetups, and quarterly hackathons - but you can participate at whatever pace works for your schedule.",
   },
   {
     id: 5,

--- a/src/constants/partners.ts
+++ b/src/constants/partners.ts
@@ -1,6 +1,6 @@
 import type { Partner } from "@/types";
 
-// Partner logos — copy your uploaded images to src/assets/partners/
+// Partner logos - copy your uploaded images to src/assets/partners/
 
 import digitalTransform from "@/assets/partners/DTCR.png";
 import giz from "@/assets/partners/GIZ.png";
@@ -102,7 +102,7 @@ export const PARTNERS: Partner[] = [
   },
 ];
 
-// Only partners that have a real logo image — used by the marquee
+// Only partners that have a real logo image - used by the marquee
 export const MARQUEE_PARTNERS = PARTNERS.filter((p) => Boolean(p.logo));
 
 // Add these exports at the bottom of your existing src/constants/partners.ts
@@ -134,7 +134,7 @@ export const PARTNER_BENEFITS = [
     iconBg: "bg-orange-100",
     iconColor: "text-orange-500",
     title: "Build real products",
-    body: "Bring a problem. We'll scope, build, and maintain an open-source tool together — you get the asset.",
+    body: "Bring a problem. We'll scope, build, and maintain an open-source tool together - you get the asset.",
   },
   {
     iconKey: "building",
@@ -156,12 +156,12 @@ export const PARTNERSHIP_STEPS = [
   {
     n: "01",
     title: "Reach out",
-    body: "Send us an email — no formal proposal needed. Just tell us who you are and what you're thinking.",
+    body: "Send us an email - no formal proposal needed. Just tell us who you are and what you're thinking.",
   },
   {
     n: "02",
     title: "We talk",
-    body: "A 30-minute call. We share what OSK does and what we need. No pitch — just an honest conversation.",
+    body: "A 30-minute call. We share what OSK does and what we need. No pitch - just an honest conversation.",
   },
   {
     n: "03",
@@ -201,6 +201,6 @@ export const PARTNER_STATS = [
 export const WHAT_WE_LOOK_FOR = [
   "Genuine interest in Rwanda's developer ecosystem",
   "Willingness to commit time, not just logo placement",
-  "Alignment with open source values — transparency, collaboration",
+  "Alignment with open source values - transparency, collaboration",
   "A specific thing you can offer: space, mentors, stipends, or hiring",
 ];

--- a/src/constants/partnersForm.ts
+++ b/src/constants/partnersForm.ts
@@ -18,19 +18,19 @@ export const PARTNERSHIP_TIERS = [
   {
     value: "gold",
     label: "Gold Partner",
-    desc: "Major commitment — deepest collaboration, highest visibility.",
+    desc: "Major commitment - deepest collaboration, highest visibility.",
     dot: "#f59e0b",
   },
   {
     value: "silver",
     label: "Silver Partner",
-    desc: "Regular involvement — recurring sessions, shared deliverables.",
+    desc: "Regular involvement - recurring sessions, shared deliverables.",
     dot: "#9ca3af",
   },
   {
     value: "community",
     label: "Community Partner",
-    desc: "Lighter touch — specific projects or events, no long-term obligation.",
+    desc: "Lighter touch - specific projects or events, no long-term obligation.",
     dot: "#2b7fff",
   },
   {

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -23,7 +23,7 @@ export const GOOD_FIRST_ISSUES: Issue[] = [
   },
   {
     id: 3,
-    title: "Fix attendance export to CSV — wrong headers",
+    title: "Fix attendance export to CSV - wrong headers",
     label: "bug",
     project: "EduTrack Rwanda",
     projectSlug: "edutrack-rwanda",

--- a/src/constants/resources.ts
+++ b/src/constants/resources.ts
@@ -17,7 +17,7 @@ export const RESOURCES: Resource[] = [
     type:        "tutorial",
     category:    "git",
     title:       "Your First Pull Request: A Complete Walkthrough",
-    description: "Everything you need to go from zero to merged PR — forking, branching, committing, and opening a pull request against an OSK project. Written for absolute beginners.",
+    description: "Everything you need to go from zero to merged PR - forking, branching, committing, and opening a pull request against an OSK project. Written for absolute beginners.",
     author:      "Didas Mbarushimana",
     authorRole:  "Community Lead",
     readTime:    "12 min read",
@@ -34,7 +34,7 @@ export const RESOURCES: Resource[] = [
     type:        "guide",
     category:    "open-source",
     title:       "How to Read Someone Else's Codebase",
-    description: "Jumping into an unfamiliar project is intimidating. This guide breaks down a repeatable system for understanding code you didn't write — fast.",
+    description: "Jumping into an unfamiliar project is intimidating. This guide breaks down a repeatable system for understanding code you didn't write - fast.",
     author:      "Tech Lead",
     authorRole:  "OSK Maintainer",
     readTime:    "8 min read",
@@ -50,7 +50,7 @@ export const RESOURCES: Resource[] = [
     slug:        "git-rebase-vs-merge",
     type:        "video",
     category:    "git",
-    title:       "Git Rebase vs Merge — Explained Simply",
+    title:       "Git Rebase vs Merge - Explained Simply",
     description: "A recorded OSK Wednesday session covering one of the most confusing Git concepts. Live examples, real project history, no hand-waving.",
     author:      "Jean-Paul H.",
     authorRole:  "OSK Contributor",
@@ -101,7 +101,7 @@ export const RESOURCES: Resource[] = [
     slug:        "open-source-career-story",
     type:        "article",
     category:    "career",
-    title:       "How Open Source Changed My Career — And How It Can Change Yours",
+    title:       "How Open Source Changed My Career - And How It Can Change Yours",
     description: "Amina Uwase went from student to Andela engineer partly through OSK. Here she breaks down how open source contribution accelerated her trajectory.",
     author:      "Amina Uwase",
     authorRole:  "Software Developer, Andela",
@@ -135,8 +135,8 @@ export const RESOURCES: Resource[] = [
     slug:        "django-beginners",
     type:        "tutorial",
     category:    "python",
-    title:       "Django for Beginners — Build Your First Model and View",
-    description: "Used in the EduTrack Rwanda sessions. Covers Django project setup, models, views, URL routing, and the admin panel — all from scratch.",
+    title:       "Django for Beginners - Build Your First Model and View",
+    description: "Used in the EduTrack Rwanda sessions. Covers Django project setup, models, views, URL routing, and the admin panel - all from scratch.",
     author:      "Tech Lead",
     authorRole:  "OSK Maintainer",
     readTime:    "25 min read",
@@ -208,7 +208,7 @@ export const EXTERNAL_TOOLS: ExternalTool[] = [
     free:        true,
   },
   {
-    name:        "YouTube — OSK Sessions",
+    name:        "YouTube - OSK Sessions",
     description: "Recorded Wednesday sessions. Full replays of every technical session we've run.",
     link:        "https://www.youtube.com/@opensourcekigali",
     iconKey:     "youtube",
@@ -217,18 +217,18 @@ export const EXTERNAL_TOOLS: ExternalTool[] = [
   },
 ];
 
-// Learning path data — used by the 3-path section
+// Learning path data - used by the 3-path section
 export const LEARNING_PATHS = [
   {
     key:     "developers",
     color:   "blue",
     icon:    "terminal",
-    label:   "Path 1 — Developers",
+    label:   "Path 1 - Developers",
     heading: "New to open source?\nStart here.",
     items: [
       "Your First Pull Request: A Complete Walkthrough",
       "How to Read Someone Else's Codebase",
-      "Git Rebase vs Merge — Explained Simply",
+      "Git Rebase vs Merge - Explained Simply",
     ],
     filterType:     "tutorial" as const,
     filterCategory: "git"      as const,
@@ -237,7 +237,7 @@ export const LEARNING_PATHS = [
     key:     "designers",
     color:   "violet",
     icon:    "layout",
-    label:   "Path 2 — Designers",
+    label:   "Path 2 - Designers",
     heading: "Never opened a PR?\nThat's okay.",
     items: [
       "Contributing to Open Source as a Designer",
@@ -251,7 +251,7 @@ export const LEARNING_PATHS = [
     key:     "writers",
     color:   "emerald",
     icon:    "rss",
-    label:   "Path 3 — Writers",
+    label:   "Path 3 - Writers",
     heading: "Words are code too.\nStart writing.",
     items: [
       "OSK Project README Template",

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -21,7 +21,7 @@ export const TEAM: TeamMember[] = [
     name: "Operations Lead",
     role: "operations-lead",
     label: "Operations Lead",
-    bio: "Turns strategy into execution — coordinating teams, tracking progress, and clearing blockers.",
+    bio: "Turns strategy into execution - coordinating teams, tracking progress, and clearing blockers.",
     initials: "OL",
     avatarBg: "#1a6fef",
     links: {},

--- a/src/hooks/useAutoPlay.ts
+++ b/src/hooks/useAutoPlay.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 
 interface UseAutoPlayOptions {
   length:    number;
-  interval?: number; // ms — default 4000
+  interval?: number; // ms - default 4000
 }
 
 interface UseAutoPlayReturn {

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -35,7 +35,7 @@ export function useFilter<T, F extends Record<string, string>>({
   searchKeys,
   filterKeys = [],
 }: UseFilterConfig<T>): UseFilterReturn<T, F> {
-  // Build initial filter state — all set to "all"
+  // Build initial filter state - all set to "all"
   const initialFilters = Object.fromEntries(
     filterKeys.map((k) => [k as string, "all"])
   ) as F;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,7 +23,7 @@ export async function postForm<T>(path: string, form: FormData): Promise<T> {
   const response = await fetch(`${BASE}${path}`, {
     method: "POST",
     body:   form,
-    // No Content-Type header — browser sets it automatically with the boundary
+    // No Content-Type header - browser sets it automatically with the boundary
   });
 
   const json = await response.json();

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -23,7 +23,7 @@ interface DotProps {
 
 //Sub-components
 
-// Purely decorative floating blob — no logic, no state
+// Purely decorative floating blob - no logic, no state
 const Dot = ({ color, size, style }: DotProps) => (
   <div
     className={`absolute rounded-full ${color} ${size}`}
@@ -101,7 +101,7 @@ const About = () => (
         </div>
       </div>
 
-      {/* Stats strip — data from ABOUT_STATS constant */}
+      {/* Stats strip - data from ABOUT_STATS constant */}
       <div className="border-b border-gray-100 bg-white">
         <div className="max-w-7xl mx-auto px-6 md:px-20 flex flex-wrap items-center justify-center gap-10 py-4">
           {ABOUT_STATS.map((s) => (
@@ -151,7 +151,7 @@ const About = () => (
           </div>
         </div>
 
-        {/* Right — numbered story points from constant */}
+        {/* Right - numbered story points from constant */}
         <div className="flex flex-col divide-y divide-gray-100">
           {STORY_POINTS.map((sp, idx) => (
             <ScrollAnimatedItem key={sp.number} delay={idx * 0.15} className="py-6 first:pt-0 last:pb-0">
@@ -205,7 +205,7 @@ const About = () => (
           <div className="space-y-4 text-gray-500 text-sm md:text-base leading-relaxed">
             <p>
               We believe Rwanda will look different after a generation of
-              developers who learned by shipping — not by watching. Just as open
+              developers who learned by shipping - not by watching. Just as open
               source transformed the global tech industry, we believe it can
               transform ours.
             </p>
@@ -236,7 +236,7 @@ const About = () => (
           </p>
         </div>
 
-        {/* Values list — data from VALUES constant */}
+        {/* Values list - data from VALUES constant */}
         <div className="divide-y divide-gray-100">
           {VALUES.map((v, idx) => (
             <ScrollAnimatedItem

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -68,7 +68,7 @@ const Community = () => (
             </p>
           </div>
 
-          {/* Right: stats — from COMMUNITY_STATS constant */}
+          {/* Right: stats - from COMMUNITY_STATS constant */}
           <div className="grid grid-cols-2 gap-3 lg:min-w-[320px]">
             {COMMUNITY_STATS.map((s) => (
               <div
@@ -109,7 +109,7 @@ const Community = () => (
           </div>
           <p className="text-gray-500 text-sm">
             <span className="font-semibold text-gray-900">1500+ people</span>{" "}
-            already building — come meet them.
+            already building - come meet them.
           </p>
           <PrimaryButton
             to="https://docs.google.com/forms/d/1L4saCJxfIi_jha0lBanIjAl-o2sEXvPs6d0J1TyW9DM/viewform"
@@ -137,7 +137,7 @@ const Community = () => (
           </p>
         </div>
 
-        {/* Social platforms — from SOCIAL_PLATFORMS constant */}
+        {/* Social platforms - from SOCIAL_PLATFORMS constant */}
         <div className="mt-14 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
           {SOCIAL_PLATFORMS.map((p, idx) => (
             <ScrollAnimatedItem key={p.name} delay={idx * 0.15}>
@@ -187,7 +187,7 @@ const Community = () => (
           </h2>
           <p className="text-gray-400 text-base leading-relaxed mb-8">
             OSK is only as good as the people in it. These aren't policies
-            written by a lawyer — they're the norms that have made this
+            written by a lawyer - they're the norms that have made this
             community a place people actually want to spend time.
           </p>
           <div className="flex items-center gap-3">
@@ -199,7 +199,7 @@ const Community = () => (
           </div>
         </div>
 
-        {/* Right: rules — from GUIDELINES constant */}
+        {/* Right: rules - from GUIDELINES constant */}
         <div className="space-y-3">
           {GUIDELINES.map((g, i) => (
             <ScrollAnimatedItem
@@ -226,7 +226,7 @@ const Community = () => (
             the Community tab won't close itself.
           </h2>
           <p className="text-gray-500 text-base md:text-lg leading-relaxed">
-            You've read enough. The next step isn't another page — it's joining
+            You've read enough. The next step isn't another page - it's joining
             the Discord, saying hi in #general, and finding your first issue.
             Takes 10 minutes.
           </p>

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -325,7 +325,7 @@ const EventCard = ({ event }: { event: OSKEvent }) => {
         {/* Past dim overlay */}
         {isPast && <div className="absolute inset-0 bg-black/20" />}
 
-        {/* Date chip — bottom-left, overlaid on header */}
+        {/* Date chip - bottom-left, overlaid on header */}
         <div className="absolute bottom-3 left-3">
           <div
             className="px-3 py-2 rounded-xl"
@@ -344,7 +344,7 @@ const EventCard = ({ event }: { event: OSKEvent }) => {
           </div>
         </div>
 
-        {/* Type badge — top-right */}
+        {/* Type badge - top-right */}
         <div className="absolute top-3 right-3">
           <TypeBadge type={event.type} />
         </div>
@@ -407,7 +407,7 @@ const EventCard = ({ event }: { event: OSKEvent }) => {
 
         <div className="flex-1" />
 
-        {/* Meta — horizontal, compact */}
+        {/* Meta - horizontal, compact */}
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-400 mb-4">
           {event.time && (
             <span className="flex items-center gap-1"><Clock size={10} style={{ color: "#5b9fff" }} />{event.time}</span>
@@ -525,13 +525,13 @@ const Event = () => {
 
               <p className="text-gray-500 text-base md:text-lg leading-relaxed max-w-lg">
                 Weekly sessions, monthly meetups, and quarterly hackathons.
-                Every event is open to all skill levels — and all of them are free.
+                Every event is open to all skill levels - and all of them are free.
               </p>
             </div>
 
             {/* Right: stats + mini calendar */}
             <div className="flex flex-col gap-4 shrink-0 w-full lg:w-72">
-              {/* Stats — derived from EVENTS constant */}
+              {/* Stats - derived from EVENTS constant */}
               <div className="grid grid-cols-3 gap-2">
                 {[
                   { n: upcomingCount,    label: "Upcoming"  },
@@ -723,7 +723,7 @@ const Event = () => {
             </h2>
             <p className="text-[#93bbff] text-base leading-relaxed mb-8">
               We run 50+ events a year. Many of the best ones were proposed by
-              community members — not the leadership team.
+              community members - not the leadership team.
             </p>
             <div className="grid grid-cols-2 gap-3">
               {[

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -173,7 +173,7 @@ const HomePage = () => {
             <SecondaryButton to="/about">Know More About Us</SecondaryButton>
           </div>
 
-          {/* Stats — from HERO_STATS constant */}
+          {/* Stats - from HERO_STATS constant */}
           <div className="flex flex-wrap justify-center md:justify-start items-center gap-6 md:gap-16 mt-16 pt-6">
             {HERO_STATS.map((stat, index) => (
               <ScrollAnimatedItem
@@ -252,7 +252,7 @@ const HomePage = () => {
             </p>
           ) : null}
 
-          {/* Featured — first project */}
+          {/* Featured - first project */}
           {!projectsLoading && !projectsError && featuredProject && (
             <div className="relative w-full bg-white rounded-2xl overflow-hidden shadow-lg mb-12 md:flex md:items-stretch border border-gray-100">
               <div className="md:w-1/2 h-64 sm:h-80 md:h-auto relative">
@@ -292,7 +292,7 @@ const HomePage = () => {
             </div>
           )}
 
-          {/* Other projects grid — remaining 3 */}
+          {/* Other projects grid - remaining 3 */}
           {!projectsLoading && !projectsError && (
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
               {homeProjects.slice(1).map((project, idx) => (
@@ -351,7 +351,7 @@ const HomePage = () => {
             grow your skills, and make meaningful impact.
           </p>
 
-          {/* Embla Carousel — from CONTRIBUTION_SLIDES constant 
+          {/* Embla Carousel - from CONTRIBUTION_SLIDES constant 
           <div className="max-w-6xl mx-auto">
             <div className="overflow-hidden" ref={emblaRef}>
               <div className="flex gap-6">
@@ -360,7 +360,7 @@ const HomePage = () => {
                     key={index}
                     className="flex-[0_0_100%] sm:flex-[0_0_50%] md:flex-[0_0_33.3333%]"
                   >
-                    {/* Contribution Card — inline 
+                    {/* Contribution Card - inline 
                     <div className="bg-slate-100 rounded-3xl p-8 flex flex-col justify-between min-h-90 transition duration-300 hover:shadow-xl text-left">
                       <div>
                         <div className="text-blue-500 mb-4">
@@ -422,7 +422,7 @@ const HomePage = () => {
       {/* EXPLORE / CONNECT */}
       <section className="bg-[#FFF7F5] py-20 px-4 md:px-20">
         <EyebrowLabel text="Connect, Contribute and Learn" className="mb-4" />
-        {/* Nav pills — from EXPLORE_LINKS constant */}
+        {/* Nav pills - from EXPLORE_LINKS constant */}
         <div className="flex flex-wrap justify-center items-center mb-16 gap-4 md:gap-8">
           {EXPLORE_LINKS.map((link) =>
             link.variant === "primary" ? (
@@ -636,7 +636,7 @@ const HomePage = () => {
             </p>
           </div>
 
-          {/* Cards — pause on hover */}
+          {/* Cards - pause on hover */}
           <div
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
             onMouseEnter={() => setPaused(true)}
@@ -750,7 +750,7 @@ const HomePage = () => {
             projects, and what to expect from the Community.
           </p>
 
-          {/* Accordion — data from FAQ_ITEMS constant */}
+          {/* Accordion - data from FAQ_ITEMS constant */}
           <div className="flex flex-col gap-3 mb-8">
             {FAQ_ITEMS.map((faq) => {
               const isOpen = openFaq === faq.id;
@@ -874,7 +874,7 @@ const HomePage = () => {
               <SecondaryButton to="">View Open Issues</SecondaryButton>
             </div>
 
-            {/* Stat pills — from CTA_STATS constant */}
+            {/* Stat pills - from CTA_STATS constant */}
             <div className="flex flex-wrap gap-3">
               {CTA_STATS.map((s) => (
                 <div
@@ -892,7 +892,7 @@ const HomePage = () => {
             </div>
           </div>
 
-          {/* Right: Activity feed — from CTA_ACTIVITY constant */}
+          {/* Right: Activity feed - from CTA_ACTIVITY constant */}
           <div className="relative">
             <div
               className="rounded-2xl overflow-hidden border border-white/10"

--- a/src/pages/MembersForm.tsx
+++ b/src/pages/MembersForm.tsx
@@ -15,7 +15,7 @@ const CODING_LEVELS: { value: CodingLevel; label: string; desc: string }[] = [
   {
     value: "beginner",
     label: "Beginner",
-    desc:  "I'm just getting started — first PR territory",
+    desc:  "I'm just getting started - first PR territory",
   },
   {
     value: "intermediate",
@@ -36,7 +36,7 @@ const AFRICAN_COUNTRIES = [
 ];
 
 // ─── Form state type ──────────────────────────────────────────────────────────
-// This is what lives in the form — friendly for the user.
+// This is what lives in the form - friendly for the user.
 // It gets mapped to CreateMemberPayload on submit.
 
 interface MemberFormState {
@@ -164,7 +164,7 @@ const MembersForm = () => {
     e.preventDefault();
     setApiError(null);
 
-    // Client-side validation first — don't hit the server if we already know it's wrong
+    // Client-side validation first - don't hit the server if we already know it's wrong
     const validationErrors = validate(values);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
@@ -179,7 +179,7 @@ const MembersForm = () => {
       // Build the exact payload the backend expects
       const payload = buildPayload(values);
 
-      // POST /members — returns ApiMember on success, throws on failure
+      // POST /members - returns ApiMember on success, throws on failure
       const member = await post<ApiMember>("/members", payload);
 
       // Store the response so we can show the member's name in the success screen
@@ -270,7 +270,7 @@ const MembersForm = () => {
           style={{ borderColor: "#c5d9ff", boxShadow: "0 1px 24px rgba(43,127,255,0.07)" }}
         >
 
-          {/* API error banner — shown when the server rejects the request */}
+          {/* API error banner - shown when the server rejects the request */}
           {apiError && (
             <div className="flex items-start gap-3 mb-6 p-4 rounded-xl bg-red-50 border border-red-200">
               <AlertCircle size={16} className="text-red-500 shrink-0 mt-0.5" />

--- a/src/pages/Partners.tsx
+++ b/src/pages/Partners.tsx
@@ -8,7 +8,7 @@ import SecondaryButton from "@/components/UI/SecondaryButton";
 import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 
 
-// Icon map for benefits — keeps PARTNER_BENEFITS JSX-free in constants
+// Icon map for benefits - keeps PARTNER_BENEFITS JSX-free in constants
 const BENEFIT_ICONS: Record<string, React.ReactNode> = {
   users: <Users size={20} />,
   book: <BookOpen size={20} />,
@@ -60,7 +60,7 @@ const Partners = () => (
     {/* ── MARQUEE */}
     <PartnerMarquee showSecondary={false} />
 
-    {/* STAT CARDS — from PARTNER_STATS constant 
+    {/* STAT CARDS - from PARTNER_STATS constant 
     <section className="py-14 px-6 md:px-20 bg-white border-b border-gray-100">
       <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-4 gap-5">
         {PARTNER_STATS.map((s, i) => (
@@ -100,7 +100,7 @@ const Partners = () => (
           </PrimaryButton>
         </div>
 
-        {/* Partner type breakdown — derived from PARTNERS constant */}
+        {/* Partner type breakdown - derived from PARTNERS constant */}
         <div className="grid grid-cols-2 gap-4">
           {[
             {
@@ -161,7 +161,7 @@ const Partners = () => (
       </div>
     </div>
 
-    {/* ── BENEFITS — from PARTNER_BENEFITS constant */}
+    {/* ── BENEFITS - from PARTNER_BENEFITS constant */}
     <section className="py-20 px-6 md:px-20 bg-white md:mt-10">
       <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-start">
 
@@ -172,7 +172,7 @@ const Partners = () => (
             <br />you build with us.
           </h2>
           <p className="text-gray-500 text-base leading-relaxed mb-8">
-            Partnerships are mutual. We ask for your support and we give something real back —
+            Partnerships are mutual. We ask for your support and we give something real back -
             every time.
           </p>
           <Link
@@ -201,7 +201,7 @@ const Partners = () => (
       </div>
     </section>
 
-    {/* ── HOW IT WORKS — from PARTNERSHIP_STEPS constant */}
+    {/* ── HOW IT WORKS - from PARTNERSHIP_STEPS constant */}
     <section className="py-20 px-6 md:px-20 bg-gray-50 border-t border-gray-100">
       <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-start">
 
@@ -242,7 +242,7 @@ const Partners = () => (
             </div>
             <div className="pt-6 border-t border-gray-100">
               <p className="text-gray-400 text-sm leading-relaxed">
-                Partnerships are open to any organisation — big or small. If you're unsure
+                Partnerships are open to any organisation - big or small. If you're unsure
                 whether you qualify, just reach out. The worst we can say is{" "}
                 <em>not yet.</em>
               </p>
@@ -303,7 +303,7 @@ const Partners = () => (
               <ArrowUpRight size={16} className="text-gray-400 group-hover:text-gray-700 transition-colors" />
             </NavLink>
 
-            {/* Social proof — derived from PARTNERS constant */}
+            {/* Social proof - derived from PARTNERS constant */}
             <div className="flex items-center gap-3 pt-2 pl-1">
               <div className="flex -space-x-2">
                 {["bg-violet-500", "bg-blue-500", "bg-emerald-500", "bg-orange-500"].map((c, i) => (

--- a/src/pages/PartnersForm.tsx
+++ b/src/pages/PartnersForm.tsx
@@ -73,8 +73,8 @@ function validate(values: PartnerFormState): Errors {
 
 // ─── Payload builder ──────────────────────────────────────────────────────────
 // The API expects multipart/form-data because it includes a binary file.
-// We build a FormData object — field names must match the API exactly.
-// "partershipReason" is the real field name in the API (one 'n') — intentional typo.
+// We build a FormData object - field names must match the API exactly.
+// "partershipReason" is the real field name in the API (one 'n') - intentional typo.
 
 function buildFormData(values: PartnerFormState): FormData {
   const form = new FormData();
@@ -185,10 +185,10 @@ const PartnersForm = () => {
     setSubmitting(true);
 
     try {
-      // Build FormData — not JSON — because the request includes a file
+      // Build FormData - not JSON - because the request includes a file
       const formData = buildFormData(values);
 
-      // POST /partners — returns ApiPartner on success, throws on failure
+      // POST /partners - returns ApiPartner on success, throws on failure
       const partner = await postForm<ApiPartner>("/partners", formData);
 
       setCreatedPartner(partner);
@@ -273,7 +273,7 @@ const PartnersForm = () => {
         </h1>
         <p className="text-gray-500 text-base max-w-md mx-auto leading-relaxed">
           Tell us about your organisation. Our partnerships lead will follow up
-          within 48 hours — no RFPs, no bureaucracy.
+          within 48 hours - no RFPs, no bureaucracy.
         </p>
       </div>
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -358,7 +358,7 @@ const IssueRow = ({ issue }: { issue: Issue }) => (
 const Projectt = () => {
   const { projects, loading, error } = useProjects();
 
-  // ── Filter hook — replaces all the inline useState filter logic
+  // ── Filter hook - replaces all the inline useState filter logic
   const {
     filtered,
     search,
@@ -430,7 +430,7 @@ const Projectt = () => {
               </p>
             </div>
 
-            {/* Stats — derived from PROJECTS constant, always accurate */}
+            {/* Stats - derived from PROJECTS constant, always accurate */}
             <div className="grid grid-cols-3 gap-px bg-white/10 rounded-2xl overflow-hidden shrink-0">
               {[
                 { n: projects.length, label: "Projects" },
@@ -526,7 +526,7 @@ const Projectt = () => {
             </div>
           ) : (
             <>
-              {/* Featured card — only when no filters active */}
+              {/* Featured card - only when no filters active */}
               {showFeatured && featured && <FeaturedCard project={featured} />}
 
               {nonFeatured.length > 0 ? (
@@ -604,7 +604,7 @@ const Projectt = () => {
             </a>
           </div>
 
-          {/* Issue list — comes from GOOD_FIRST_ISSUES constant */}
+          {/* Issue list - comes from GOOD_FIRST_ISSUES constant */}
           <div className="lg:col-span-3 bg-white rounded-2xl border border-gray-100 p-5 shadow-sm">
             <div className="flex items-center justify-between mb-2 pb-3 border-b border-gray-100">
               <p className="text-sm font-black text-gray-900">Open Issues</p>
@@ -652,7 +652,7 @@ const Projectt = () => {
             </h2>
             <p className="text-white/50 text-base leading-relaxed">
               OSK incubates open-source projects that address genuine challenges
-              in Rwanda and Africa. Bring your idea — we'll help you build a
+              in Rwanda and Africa. Bring your idea - we'll help you build a
               team.
             </p>
           </div>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -8,7 +8,7 @@ import { RESOURCES, EXTERNAL_TOOLS, LEARNING_PATHS } from "@/constants";
 import type { Resource, ResourceType, ResourceCategory } from "@/types";
 import EyebrowLabel from "../components/UI/EyebrowLable";
 
-// ─── Meta maps — kept in the component file since they
+// ─── Meta maps - kept in the component file since they
 //     contain JSX (icons) and are only used here ─────────────────────────────
 
 const TYPE_META: Record<
@@ -382,7 +382,7 @@ const Resources = () => {
               </span>
             </h1>
             <p className="text-gray-500 text-base md:text-lg leading-relaxed max-w-xl">
-              Tutorials, guides, templates, tools, and recorded sessions — all
+              Tutorials, guides, templates, tools, and recorded sessions - all
               written by OSK contributors, for OSK contributors. Practical.
               Rwanda-specific. Free.
             </p>
@@ -644,7 +644,7 @@ const Resources = () => {
               <span className="text-primary-colour">Teach the Community.</span>
             </h2>
             <p className="text-gray-400 text-base leading-relaxed">
-              The best resources on this page were written by OSK contributors —
+              The best resources on this page were written by OSK contributors -
               not staff. If you've learned something the hard way, write it up
               and share it. A good tutorial saves the next ten people your pain.
             </p>
@@ -655,7 +655,7 @@ const Resources = () => {
               Submit a resource
             </h3>
             <p className="text-gray-500 text-sm leading-relaxed mb-6">
-              Tutorials, guides, templates, recorded sessions — anything that
+              Tutorials, guides, templates, recorded sessions - anything that
               helps someone contribute better.
             </p>
 

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -18,7 +18,7 @@ export type ApiResponse<T> = ApiSuccess<T> | ApiError;
 
 // ── Member ─────────────────────────────────────────────────────────────────────
 
-// The three values the API accepts for codingLevel — nothing else is valid
+// The three values the API accepts for codingLevel - nothing else is valid
 export type CodingLevel = "beginner" | "intermediate" | "advanced";
 
 // Shape of a member returned by the API
@@ -64,7 +64,7 @@ export interface CreatePartnerPayload {
   logoUrl:          string;
   description:      string;
   email:            string;
-  partershipReason: string; // intentional — matches the API typo
+  partershipReason: string; // intentional - matches the API typo
 }
 
 // ── Project ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Removes em dash characters from website source text and displayed fallback values, replacing them with simple hyphens.

## Related issue

Closes #149

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Tested locally in the browser
- [x] New data is in `src/constants/`, not hardcoded in a component
- [x] No `console.log` statements left in the code

## Screenshots (if UI change)

N/A

## Notes for the reviewer

There is no standalone `typecheck` script in `package.json`; `npm run build` runs `tsc -b` before the Vite build.
