### PR TITLE
fix: clean up footer links, Events Discord button, and team role casing

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -158,9 +158,6 @@ const Footer = () => {
         <div className="pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-gray-600">
           <p>© {currentYear} Open Source Kigali. All rights reserved.</p>
           <div className="flex gap-5">
-            <NavLink to="/privacy" className="hover:text-gray-400 transition">
-              Privacy Policy
-            </NavLink>
             <a
               href="https://docs.google.com/document/d/1K_bIZT09p-8IiPpg1v3RsMD2dZmUzRFWlMp8tfOavcE/edit?usp=sharing"
               target="_blank"
@@ -169,9 +166,6 @@ const Footer = () => {
             >
               Code of Conduct
             </a>
-            <NavLink to="/charter" className="hover:text-gray-400 transition">
-              Community Charter
-            </NavLink>
           </div>
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,14 +27,7 @@ const linkGroups: FooterLinkGroup[] = [
       { label: "Contribution Guide", to: "/projects" },
     ],
   },
-  {
-    heading: "Resources",
-    links: [
-      // { label: "Tutorials", to: "/resources" },
-      { label: "Blog", to: "/blog" },
-      { label: "Events", to: "/events" },
-    ],
-  },
+
   {
     heading: "Connect",
     links: [
@@ -54,7 +47,7 @@ const linkGroups: FooterLinkGroup[] = [
         external: true,
       },
       {
-        label: "contact@oskigali.org",
+        label: "Contact Us",
         to: "https://mail.google.com/mail/?view=cm&to=contact@oskigali.org",
         external: true,
       },

--- a/src/constants/about.ts
+++ b/src/constants/about.ts
@@ -62,7 +62,7 @@ export const VALUES = [
 export const ABOUT_TEAM = [
   {
     name: "Didas Mbarushimana Daniel",
-    role: "COMMUNITY LEAD",
+    role: "Community Lead",
     initials: "DD",
     bg: "bg-blue-500",
     avatar: didasImg,
@@ -79,7 +79,7 @@ export const ABOUT_TEAM = [
   },
   {
     name: "Nancy Teta Kwizera",
-    role: "OPERATIONS LEAD",
+    role: "Operations Lead",
     initials: "OL",
     bg: "bg-emerald-500",
     avatar: zaraImg,

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -647,17 +647,6 @@ const Event = () => {
           </div>
           <div className="flex gap-3 shrink-0">
             <a
-              href="https://discord.com/invite/3dTFZSn6Tq"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-5 py-2.5 rounded-full text-white text-sm font-bold transition-colors"
-              style={{ background: "#2b7fff" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "#1a6fef")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "#2b7fff")}
-            >
-              Join Discord
-            </a>
-            <a
               href="https://chat.whatsapp.com/GimdjJcYLyyG62zpgsI0zB"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
## Changes

- **Footer bottom row**: Remove Privacy Policy (#164) and Community Charter (#165) links, keep Code of Conduct
- **Events page**: Remove Join Discord button from notify strip (#167)
- **Team roles**: Fix uppercase casing — COMMUNITY LEAD → Community Lead (#169), OPERATIONS LEAD → Operations Lead (#170)

Closes #164, #165, #167, #169, #170