### PR TITLE
Remove privacy policy message from footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -165,9 +165,9 @@ const Footer = () => {
         <div className="pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-gray-600">
           <p>© {currentYear} Open Source Kigali. All rights reserved.</p>
           <div className="flex gap-5">
-            <NavLink to="/privacy" className="hover:text-gray-400 transition">
+            {/* <NavLink to="/privacy" className="hover:text-gray-400 transition">
               Privacy Policy
-            </NavLink>
+            </NavLink> */}
             <a
               href="https://docs.google.com/document/d/1K_bIZT09p-8IiPpg1v3RsMD2dZmUzRFWlMp8tfOavcE/edit?usp=sharing"
               target="_blank"


### PR DESCRIPTION
## What does this PR do?

This PR removed privacy policy on the footer section

## Related issue

Closes #164 

## Type of change

- [ x
<img width="811" height="135" alt="Screenshot 2026-05-29 at 22 35 21" src="https://github.com/user-attachments/assets/6cf20a8c-6710-4543-bf6a-51ea9230e989" />
<img width="797" height="130" alt="Screenshot 2026-05-29 at 22 35 28" src="https://github.com/user-attachments/assets/d21f0f28-472e-4bc7-9373-b58d21a6c6cf" />
] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [ ] No `console.log` statements left in the code

## Screenshots (if UI change)

<!-- Paste before/after screenshots here -->

## Notes for the reviewer

<!-- Anything you want the reviewer to pay attention to -->