### PR TITLE
feat: replace hardcoded stats with live /stats data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the OSK backend API (no trailing slash).
+# Copy this file to .env and adjust if you run the API locally.
+VITE_API_BASE_URL=https://api.oskigali.org/api

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist-ssr
 # Environment variables (CRITICAL)
 .env
 .env.*
+!.env.example
 *.local
 
 # Coverage

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
 export { BASE_URL, apiGet } from "./client";
 export { fetchProjects } from "./projects";
 export { fetchEvents } from "./events";
+export { fetchStats } from "./stats";

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,0 +1,6 @@
+import type { Stats } from "@/types";
+import { apiGet } from "./client";
+
+export async function fetchStats(): Promise<Stats> {
+  return apiGet<Stats>("/stats");
+}

--- a/src/components/UI/Skeleton.tsx
+++ b/src/components/UI/Skeleton.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+/**
+ * A pulsing placeholder shown while data is loading.
+ * Pass a className to size it (and recolor it, e.g. bg-white/20 on dark areas).
+ *
+ * Usage:
+ *   {loading ? <Skeleton className="h-8 w-16" /> : <span>{value}</span>}
+ */
+export const Skeleton = ({ className }: SkeletonProps) => (
+  <span
+    aria-hidden="true"
+    className={cn(
+      "inline-block align-middle animate-pulse rounded bg-gray-200",
+      className
+    )}
+  />
+);

--- a/src/components/UI/index.ts
+++ b/src/components/UI/index.ts
@@ -4,4 +4,5 @@ export { Avatar }       from "./Avatar";
 export { Card }         from "./Card";
 export { SectionLabel } from "./SectionLabel";
 export { AttendeeBar }  from "./AttendeeBar";
+export { Skeleton }     from "./Skeleton";
 export { default as Loader } from "./Loader";

--- a/src/constants/about.ts
+++ b/src/constants/about.ts
@@ -7,11 +7,12 @@ import kingImg from "@/assets/team/Kinf.jpg";
 import zaraImg from "@/assets/team/Zara.jpg";
 import felixImg from "@/assets/team/Felix.jpg";
 import nandineImg from '@/assets/team/Nandin.jpg'
+import type { StatDisplay } from "@/types";
 
-export const ABOUT_STATS = [
-  { value: "12+", label: "Active Contributors" },
-  { value: "10", label: "Projects Shipped" },
-  { value: "25+", label: "Pull Requests Merged" },
+export const ABOUT_STATS: StatDisplay[] = [
+  { key: "contributors", label: "Active Contributors",  suffix: "+" },
+  { key: "projects",     label: "Projects Shipped" },
+  { key: "pullRequests", label: "Pull Requests Merged", suffix: "+" },
 ];
 
 export const STORY_POINTS = [

--- a/src/constants/about.ts
+++ b/src/constants/about.ts
@@ -10,9 +10,9 @@ import nandineImg from '@/assets/team/Nandin.jpg'
 import type { StatDisplay } from "@/types";
 
 export const ABOUT_STATS: StatDisplay[] = [
-  { key: "contributors", label: "Active Contributors",  suffix: "+" },
+  { key: "contributors", label: "Active Contributors" },
   { key: "projects",     label: "Projects Shipped" },
-  { key: "pullRequests", label: "Pull Requests Merged", suffix: "+" },
+  { key: "pullRequests", label: "Pull Requests Merged" },
 ];
 
 export const STORY_POINTS = [

--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -1,9 +1,9 @@
 import type { StatDisplay } from "@/types";
 
 export const COMMUNITY_STATS: StatDisplay[] = [
-  { key: "members",      label: "Members",       sub: "and growing",       suffix: "+" },
+  { key: "members",      label: "Members",       sub: "and growing" },
   { key: "events",       label: "Sessions held", sub: "More to come" },
-  { key: "pullRequests", label: "Pull requests", sub: "merged on GitHub",  suffix: "+" },
+  { key: "pullRequests", label: "Pull requests", sub: "merged on GitHub" },
   { key: "projects",     label: "Live projects", sub: "open to contribute" },
 ];
 

--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -1,8 +1,10 @@
-export const COMMUNITY_STATS = [
-  { value: "1500+", label: "Members", sub: "and growing" },
-  { value: "1", label: "Sessions held", sub: "More to come" },
-  { value: "25+", label: "Pull requests", sub: "merged on GitHub" },
-  { value: "4", label: "Live projects", sub: "open to contribute" },
+import type { StatDisplay } from "@/types";
+
+export const COMMUNITY_STATS: StatDisplay[] = [
+  { key: "members",      label: "Members",       sub: "and growing",       suffix: "+" },
+  { key: "events",       label: "Sessions held", sub: "More to come" },
+  { key: "pullRequests", label: "Pull requests", sub: "merged on GitHub",  suffix: "+" },
+  { key: "projects",     label: "Live projects", sub: "open to contribute" },
 ];
 
 export const CHANNELS = [

--- a/src/constants/homepage.ts
+++ b/src/constants/homepage.ts
@@ -13,9 +13,9 @@ export const HERO_STATS: StatDisplay[] = [
 
 // ─── About strip
 export const ABOUT_STRIP_STATS: StatDisplay[] = [
-  { key: "contributors", label: "Active Contributors",   suffix: "+" },
+  { key: "contributors", label: "Active Contributors" },
   { key: "projects",     label: "Projects Shipped" },
-  { key: "pullRequests", label: "Pull Requests Merged",  suffix: "+" },
+  { key: "pullRequests", label: "Pull Requests Merged" },
 ];
 
 // ─── Contribution roles
@@ -246,8 +246,8 @@ export const CTA_ACTIVITY: ActivityItem[] = [
 ];
 
 export const CTA_STATS: StatDisplay[] = [
-  { key: "contributors", label: "Contributors",   suffix: "+" },
-  { key: "pullRequests", label: "Pull Requests",  suffix: "+" },
+  { key: "contributors", label: "Contributors" },
+  { key: "pullRequests", label: "Pull Requests" },
   { key: "projects",     label: "Active Projects" },
 ];
 

--- a/src/constants/homepage.ts
+++ b/src/constants/homepage.ts
@@ -1,19 +1,21 @@
 // src/constants/homepage.ts
 // ── All data that lives exclusively on the homepage
 
-// ─── Hero
-export const HERO_STATS = [
-  { number: 12, label: "Contributors" },
-  { number: 25, label: "Pull Requests" },
-  { number: 3, label: "Projects" },
-  { number: 1500, label: "Active Members" },
+import type { StatDisplay } from "@/types";
+
+// ─── Hero — numbers come live from GET /stats; these define which stat + label
+export const HERO_STATS: StatDisplay[] = [
+  { key: "contributors", label: "Contributors" },
+  { key: "pullRequests", label: "Pull Requests" },
+  { key: "projects",     label: "Projects" },
+  { key: "members",      label: "Active Members" },
 ];
 
 // ─── About strip
-export const ABOUT_STRIP_STATS = [
-  { value: "12+", label: "Active Contributors" },
-  { value: "10", label: "Projects Shipped" },
-  { value: "25+", label: "Pull Requests Merged" },
+export const ABOUT_STRIP_STATS: StatDisplay[] = [
+  { key: "contributors", label: "Active Contributors",   suffix: "+" },
+  { key: "projects",     label: "Projects Shipped" },
+  { key: "pullRequests", label: "Pull Requests Merged",  suffix: "+" },
 ];
 
 // ─── Contribution roles
@@ -243,10 +245,10 @@ export const CTA_ACTIVITY: ActivityItem[] = [
   },
 ];
 
-export const CTA_STATS = [
-  { value: "12+", label: "Contributors" },
-  { value: "25+", label: "Pull Requests" },
-  { value: "10", label: "Active Projects" },
+export const CTA_STATS: StatDisplay[] = [
+  { key: "contributors", label: "Contributors",   suffix: "+" },
+  { key: "pullRequests", label: "Pull Requests",  suffix: "+" },
+  { key: "projects",     label: "Active Projects" },
 ];
 
 // ─── FAQ

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,4 +6,5 @@ export { useForm } from "./useForm";
 export { useLocalStorage } from "./useLocalStorage";
 export { useProjects } from "./useProjects";
 export { useEvents } from "./useEvents";
+export { useStats } from "./useStats";
 export { useScrollAnimation } from "./useScrollAnimation";

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { Stats } from "@/types";
+import { fetchStats } from "@/api";
+
+interface UseStatsReturn {
+  stats: Stats | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useStats(): UseStatsReturn {
+  const [stats, setStats]     = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchStats()
+      .then((data) => {
+        if (!cancelled) {
+          setStats(data);
+          setError(null);
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { stats, loading, error };
+}

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -15,12 +15,11 @@ export function formatCount(n: number, suffix = "+"): string {
 }
 
 /**
- * Formats a community stat: number with commas plus an optional suffix.
- * formatStat(1500)        → "1,500"
- * formatStat(12, "+")     → "12+"
+ * Formats a community stat with a leading "+".
+ * formatStat(1500) → "+1,500"
  */
-export function formatStat(value: number, suffix = ""): string {
-  return `${formatNumber(value)}${suffix}`;
+export function formatStat(value: number): string {
+  return `+${formatNumber(value)}`;
 }
 
 /**

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -15,6 +15,15 @@ export function formatCount(n: number, suffix = "+"): string {
 }
 
 /**
+ * Formats a community stat: number with commas plus an optional suffix.
+ * formatStat(1500)        → "1,500"
+ * formatStat(12, "+")     → "12+"
+ */
+export function formatStat(value: number, suffix = ""): string {
+  return `${formatNumber(value)}${suffix}`;
+}
+
+/**
  * Returns a capacity string.
  * formatCapacity(34, null) → "Unlimited"
  * formatCapacity(34, 80)   → "34 / 80"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,5 +1,7 @@
 import { FaXTwitter, FaLinkedinIn, FaInstagram, FaFacebookF,FaGithub, FaFigma,} from "react-icons/fa6";
 import { ABOUT_STATS, STORY_POINTS, VALUES, ABOUT_TEAM } from "@/constants";
+import { useStats } from "@/hooks";
+import { formatStat } from "@/lib/formatters";
 import image13 from "@/assets/images/open13.jpg";
 import image4 from "@/assets/images/open4.jpg";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
@@ -29,7 +31,10 @@ const Dot = ({ color, size, style }: DotProps) => (
 // Reusable pill badge used in every section header
 
 //Page
-const About = () => (
+const About = () => {
+  const { stats } = useStats();
+
+  return (
   <div className="font-sans">
     {/* ── HERO */}
     <section className="relative bg-white overflow-hidden pt-16 pb-0">
@@ -102,7 +107,7 @@ const About = () => (
           {ABOUT_STATS.map((s) => (
             <div key={s.label} className="flex items-center gap-3 text-center">
               <span className="font-black text-primary-colour text-3xl md:text-4xl">
-                {s.value}
+                {formatStat(stats?.[s.key] ?? 0, s.suffix)}
               </span>
               <span className="text-gray-500 text-base uppercase">
                 {s.label}
@@ -406,6 +411,7 @@ const About = () => (
       </div>
     </section>
   </div>
-);
+  );
+};
 
 export default About;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,6 +2,7 @@ import { FaXTwitter, FaLinkedinIn, FaInstagram, FaFacebookF,FaGithub, FaFigma,} 
 import { ABOUT_STATS, STORY_POINTS, VALUES, ABOUT_TEAM } from "@/constants";
 import { useStats } from "@/hooks";
 import { formatStat } from "@/lib/formatters";
+import { Skeleton } from "@/components/UI";
 import image13 from "@/assets/images/open13.jpg";
 import image4 from "@/assets/images/open4.jpg";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
@@ -32,7 +33,7 @@ const Dot = ({ color, size, style }: DotProps) => (
 
 //Page
 const About = () => {
-  const { stats } = useStats();
+  const { stats, loading } = useStats();
 
   return (
   <div className="font-sans">
@@ -107,7 +108,11 @@ const About = () => {
           {ABOUT_STATS.map((s) => (
             <div key={s.label} className="flex items-center gap-3 text-center">
               <span className="font-black text-primary-colour text-3xl md:text-4xl">
-                {formatStat(stats?.[s.key] ?? 0, s.suffix)}
+                {loading ? (
+                  <Skeleton className="h-7 md:h-8 w-14" />
+                ) : (
+                  formatStat(stats?.[s.key] ?? 0, s.suffix)
+                )}
               </span>
               <span className="text-gray-500 text-base uppercase">
                 {s.label}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -111,7 +111,7 @@ const About = () => {
                 {loading ? (
                   <Skeleton className="h-7 md:h-8 w-14" />
                 ) : (
-                  formatStat(stats?.[s.key] ?? 0, s.suffix)
+                  formatStat(stats?.[s.key] ?? 0)
                 )}
               </span>
               <span className="text-gray-500 text-base uppercase">

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -80,7 +80,7 @@ const Community = () => {
                   {loading ? (
                     <Skeleton className="h-7 w-16" />
                   ) : (
-                    formatStat(stats?.[s.key] ?? 0, s.suffix)
+                    formatStat(stats?.[s.key] ?? 0)
                   )}
                 </p>
                 <p className="text-gray-800 text-sm font-semibold">{s.label}</p>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,5 +1,7 @@
 import {Github,MessageCircle,Linkedin,Twitter,ArrowUpRight,Shield} from "lucide-react";
 import { COMMUNITY_STATS, GUIDELINES, SOCIAL_PLATFORMS } from "@/constants";
+import { useStats } from "@/hooks";
+import { formatStat } from "@/lib/formatters";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
 import PrimaryButton from "@/components/UI/PrimaryButton";
 import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
@@ -17,7 +19,10 @@ const SOCIAL_ICONS: Record<string, React.ReactNode> = {
 // ─── Sub-components
 
 // ─── Page
-const Community = () => (
+const Community = () => {
+  const { stats } = useStats();
+
+  return (
   <>
     {/* HERO */}
     <section className="pt-32 pb-20 px-6 md:px-20 bg-[#FFFBF7] relative overflow-hidden">
@@ -71,7 +76,7 @@ const Community = () => (
                 className="bg-white rounded-2xl border border-gray-100 p-5 shadow-sm"
               >
                 <p className="text-3xl font-black text-gray-900 leading-none mb-1">
-                  {s.value}
+                  {formatStat(stats?.[s.key] ?? 0, s.suffix)}
                 </p>
                 <p className="text-gray-800 text-sm font-semibold">{s.label}</p>
                 <p className="text-gray-400 text-xs mt-0.5">{s.sub}</p>
@@ -263,6 +268,7 @@ const Community = () => (
       </div>
     </section>
   </>
-);
+  );
+};
 
 export default Community;

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -2,6 +2,7 @@ import {Github,MessageCircle,Linkedin,Twitter,ArrowUpRight,Shield} from "lucide-
 import { COMMUNITY_STATS, GUIDELINES, SOCIAL_PLATFORMS } from "@/constants";
 import { useStats } from "@/hooks";
 import { formatStat } from "@/lib/formatters";
+import { Skeleton } from "@/components/UI";
 import EyebrowLabel from "@/components/UI/EyebrowLable";
 import PrimaryButton from "@/components/UI/PrimaryButton";
 import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
@@ -20,7 +21,7 @@ const SOCIAL_ICONS: Record<string, React.ReactNode> = {
 
 // ─── Page
 const Community = () => {
-  const { stats } = useStats();
+  const { stats, loading } = useStats();
 
   return (
   <>
@@ -76,7 +77,11 @@ const Community = () => {
                 className="bg-white rounded-2xl border border-gray-100 p-5 shadow-sm"
               >
                 <p className="text-3xl font-black text-gray-900 leading-none mb-1">
-                  {formatStat(stats?.[s.key] ?? 0, s.suffix)}
+                  {loading ? (
+                    <Skeleton className="h-7 w-16" />
+                  ) : (
+                    formatStat(stats?.[s.key] ?? 0, s.suffix)
+                  )}
                 </p>
                 <p className="text-gray-800 text-sm font-semibold">{s.label}</p>
                 <p className="text-gray-400 text-xs mt-0.5">{s.sub}</p>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -8,7 +8,7 @@ import { formatStat } from "@/lib/formatters";
 import { HERO_STATS, EXPLORE_LINKS, TESTIMONIALS, CTA_ACTIVITY, CTA_STATS, FAQ_ITEMS} from "@/constants";
 import type { HomeEventType, ActivityIconKey } from "@/constants";
 import PartnersMarquee from "@/components/UI/PartnersMarquee";
-import { Loader } from "@/components/UI";
+import { Loader, Skeleton } from "@/components/UI";
 import { ScrollAnimatedItem } from "@/components/UI/ScrollAnimatedItem";
 import HeroSlideshow from '@/pages/Home/components/HeroSlideshow';
 import heroImages from '@/pages/Home/data/heroImages';
@@ -92,7 +92,7 @@ const HomePage = () => {
 
   // Events for homepage (upcoming, capped at 4)
   const { events, loading: eventsLoading, error: eventsError } = useEvents();
-  const { stats } = useStats();
+  const { stats, loading: statsLoading } = useStats();
   const homeEvents = events
     .filter((e) => e.status !== "past")
     .slice(0, 4)
@@ -157,7 +157,11 @@ const HomePage = () => {
                 } text-center md:text-left`}
               >
                 <p className="text-2xl sm:text-3xl md:text-4xl font-bold text-white">
-                  <CountUp end={stats?.[stat.key] ?? 0} duration={5} separator="," />
+                  {statsLoading ? (
+                    <Skeleton className="h-8 md:h-9 w-16 bg-white/20" />
+                  ) : (
+                    <CountUp end={stats?.[stat.key] ?? 0} duration={5} separator="," />
+                  )}
                 </p>
                 <p className="text-sm sm:text-base md:text-lg text-primary-colour font-medium mt-1">
                   {stat.label}
@@ -775,7 +779,11 @@ const HomePage = () => {
                   className="px-4 py-2 rounded-full border border-white/10 bg-white/5"
                 >
                   <span className="text-white font-bold text-sm">
-                    {formatStat(stats?.[s.key] ?? 0, s.suffix)}
+                    {statsLoading ? (
+                      <Skeleton className="h-3.5 w-8 bg-white/20" />
+                    ) : (
+                      formatStat(stats?.[s.key] ?? 0, s.suffix)
+                    )}
                   </span>
                   <span className="text-gray-500 text-sm ml-1.5">
                     {s.label}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -3,7 +3,8 @@ import { NavLink } from "react-router";
 //import useEmblaCarousel from "embla-carousel-react";
 import CountUp from "react-countup";
 import { ChevronLeft, ChevronRight, Quote, GitMerge, UserPlus, GitPullRequest, Zap, ArrowRight,  Calendar, Clock, MapPin, Plus, Minus} from "lucide-react";
-import { useAutoPlay, useProjects, useEvents } from "@/hooks";
+import { useAutoPlay, useProjects, useEvents, useStats } from "@/hooks";
+import { formatStat } from "@/lib/formatters";
 import { HERO_STATS, EXPLORE_LINKS, TESTIMONIALS, CTA_ACTIVITY, CTA_STATS, FAQ_ITEMS} from "@/constants";
 import type { HomeEventType, ActivityIconKey } from "@/constants";
 import PartnersMarquee from "@/components/UI/PartnersMarquee";
@@ -91,6 +92,7 @@ const HomePage = () => {
 
   // Events for homepage (upcoming, capped at 4)
   const { events, loading: eventsLoading, error: eventsError } = useEvents();
+  const { stats } = useStats();
   const homeEvents = events
     .filter((e) => e.status !== "past")
     .slice(0, 4)
@@ -155,7 +157,7 @@ const HomePage = () => {
                 } text-center md:text-left`}
               >
                 <p className="text-2xl sm:text-3xl md:text-4xl font-bold text-white">
-                  <CountUp end={stat.number} duration={5} separator="," />
+                  <CountUp end={stats?.[stat.key] ?? 0} duration={5} separator="," />
                 </p>
                 <p className="text-sm sm:text-base md:text-lg text-primary-colour font-medium mt-1">
                   {stat.label}
@@ -773,7 +775,7 @@ const HomePage = () => {
                   className="px-4 py-2 rounded-full border border-white/10 bg-white/5"
                 >
                   <span className="text-white font-bold text-sm">
-                    {s.value}
+                    {formatStat(stats?.[s.key] ?? 0, s.suffix)}
                   </span>
                   <span className="text-gray-500 text-sm ml-1.5">
                     {s.label}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -160,7 +160,7 @@ const HomePage = () => {
                   {statsLoading ? (
                     <Skeleton className="h-8 md:h-9 w-16 bg-white/20" />
                   ) : (
-                    <CountUp end={stats?.[stat.key] ?? 0} duration={5} separator="," />
+                    <CountUp prefix="+" end={stats?.[stat.key] ?? 0} duration={5} separator="," />
                   )}
                 </p>
                 <p className="text-sm sm:text-base md:text-lg text-primary-colour font-medium mt-1">
@@ -782,7 +782,7 @@ const HomePage = () => {
                     {statsLoading ? (
                       <Skeleton className="h-3.5 w-8 bg-white/20" />
                     ) : (
-                      formatStat(stats?.[s.key] ?? 0, s.suffix)
+                      formatStat(stats?.[s.key] ?? 0)
                     )}
                   </span>
                   <span className="text-gray-500 text-sm ml-1.5">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,3 +51,9 @@ export type {
 } from "./api.types";
 
 export type { PartnerFormState } from "./partnersForm.types";
+
+export type {
+  Stats,
+  StatKey,
+  StatDisplay,
+} from "./stats.types";

--- a/src/types/stats.types.ts
+++ b/src/types/stats.types.ts
@@ -13,10 +13,9 @@ export interface Stats {
 export type StatKey = keyof Stats;
 
 // A stat as displayed on a page: which live value to show, its label, and
-// optional sub-text / suffix. The number itself comes from the API.
+// optional sub-text. The number itself comes from the API.
 export interface StatDisplay {
-  key:     StatKey;
-  label:   string;
-  sub?:    string;
-  suffix?: string;
+  key:   StatKey;
+  label: string;
+  sub?:  string;
 }

--- a/src/types/stats.types.ts
+++ b/src/types/stats.types.ts
@@ -1,0 +1,22 @@
+// Community stats returned by GET /stats — the API shape and the UI shape are
+// identical, so no transform is needed.
+export interface Stats {
+  contributors: number;
+  members:      number;
+  projects:     number;
+  events:       number;
+  partners:     number;
+  reviews:      number;
+  pullRequests: number;
+}
+
+export type StatKey = keyof Stats;
+
+// A stat as displayed on a page: which live value to show, its label, and
+// optional sub-text / suffix. The number itself comes from the API.
+export interface StatDisplay {
+  key:     StatKey;
+  label:   string;
+  sub?:    string;
+  suffix?: string;
+}


### PR DESCRIPTION
## What does this PR do?

Replaces the hardcoded community stats on the Home, About, and Community pages with live data from the backend `GET /stats` endpoint. Shows skeleton placeholders while loading and prefixes each metric with `+`.

## Related issue

N/A

## Type of change

- [x] New feature

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Tested locally in the browser
- [x] New data is in `src/constants/`, not hardcoded in a component
- [x] No `console.log` statements left in the code

## Notes for the reviewer

Adds a `useStats` hook + `fetchStats` API call, a reusable `Skeleton` UI primitive, and a committed `.env.example` (`VITE_API_BASE_URL`) since the API base URL was previously unconfigurable.