### PR TITLE
Footer Image alt text Fix

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,7 +101,7 @@ const Footer = () => {
             <NavLink to="/" className="inline-block mb-4">
               <img
                 src={whiteLogo}
-                alt="Opeen source kigali logo"
+                alt="Open Source Kigali logo"
                 className=" w-24 md:w-32 "
               />
             </NavLink>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,10 @@ import whiteLogo from "@/assets/Logo/OSK-primary-logo-1200-400-white.svg";
 import { Mail } from "lucide-react";
 import { FiGithub, FiTwitter, FiLinkedin } from "react-icons/fi";
 import { FaWhatsapp } from "react-icons/fa";
-import socilLink from "@/config/links"
+import socilLink from "@/config/links";
 interface FooterLinkGroup {
   heading: string;
-  links: { label: string ; to: string; external?: boolean }[];
+  links: { label: string; to: string; external?: boolean }[];
 }
 
 const linkGroups: FooterLinkGroup[] = [
@@ -29,7 +29,6 @@ const linkGroups: FooterLinkGroup[] = [
   {
     heading: "Resources",
     links: [
-      // { label: "Tutorials", to: "/resources" },
       { label: "Blog", to: "/blog" },
       { label: "Events", to: "/events" },
     ],
@@ -164,9 +163,6 @@ const Footer = () => {
         <div className="pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-gray-600">
           <p>© {currentYear} Open Source Kigali. All rights reserved.</p>
           <div className="flex gap-5">
-            {/* <NavLink to="/privacy" className="hover:text-gray-400 transition">
-              Privacy Policy
-            </NavLink> */}
             <a
               href="https://docs.google.com/document/d/1K_bIZT09p-8IiPpg1v3RsMD2dZmUzRFWlMp8tfOavcE/edit?usp=sharing"
               target="_blank"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly in 1-3 sentences -->

Fixed typo for alt image located in `Footer.tsx` component.

## Related issue

Closes #223 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [X] `npm run lint` passes
- [X] `npm run typecheck` passes
- [X] `npm run build` passes
- [X] Tested locally in the browser
- [X] New data is in `src/constants/`, not hardcoded in a component
- [X] No `console.log` statements left in the code

## Screenshots (if UI change)

<!-- Paste before/after screenshots here -->

## Notes for the reviewer

<!-- Anything you want the reviewer to pay attention to -->