### PR TITLE
fix: fixed the logo's behavior for mobile screens

### DIFF
--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -44,7 +44,7 @@ const Navbar = () => {
         {/* Logo */}
         <Link to="/" className="flex items-center">
           <img
-            src={logo}
+            src={!mobileOpen ? logo : LogoImage}
             alt="Open Source Kigali"
             className="h-10 sm:h-12 md:h-14 w-auto object-contain transition-all duration-300"
           />


### PR DESCRIPTION
## Fix mobile hamburger menu logo visibility on initial scroll state


When opening the mobile hamburger menu, the logo text ("Open Source Kigali") remains white on a white background, making it invisible. Previously, the dark version of the logo was only triggered after scrolling down 50 pixels.

This PR ensures that clicking the hamburger menu immediately forces the dark version of the logo to display, ensuring full visibility even at the top of the page.


## Type of change

- [x] Bug fix

## Screenshot
<img width="235" height="399" alt="Screenshot 2026-07-12 215733" src="https://github.com/user-attachments/assets/6d9fd925-1434-40c9-915a-48b9fb8a0c14" />
<img width="230" height="415" alt="Screenshot 2026-07-13 005111" src="https://github.com/user-attachments/assets/f2e08a44-2a9f-4073-9082-565d5e1cbba7" />


## Notes for the reviewer

This PR is not attached to any existing issue ! 