### PR TITLE
Fix View Open Issues button linking to empty string

### DIFF
--- a/src/pages/Home/components/CTA.tsx
+++ b/src/pages/Home/components/CTA.tsx
@@ -5,7 +5,6 @@ import {  CTA_ACTIVITY, CTA_STATS} from "@/constants";
 import primaryCTALink from '@/config/links'
 import { Skeleton } from "@/components/UI";
 import PrimaryButton from "@/components/UI/PrimaryButton";
-import SecondaryButton from "@/components/UI/SecondaryButton";
 import {   useStats } from "@/hooks";
 import type { ActivityIconKey } from "@/constants";
 
@@ -74,7 +73,14 @@ const CTA = () => {
                   className="group-hover:translate-x-0.5 transition-transform"
                 />
               </PrimaryButton>
-              <SecondaryButton to="">View Open Issues</SecondaryButton>
+              
+              <a href="https://github.com/Open-Source-Kigali/osk-frontend/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 text-sm sm:text-base px-5 py-2.5 md:px-7 md:py-3 bg-transparent hover:bg-primary-colour text-blue-500 hover:text-white border border-blue-500 hover:scale-[1.05] hover:shadow-lg font-semibold rounded-full transition"
+              >
+                View Open Issues
+              </a>
             </div>
 
             {/* Stat pills — from CTA_STATS constant */}


### PR DESCRIPTION
Fixes the "View Open Issues" button on the homepage CTA section, which
linked to an empty string and either reloaded the page or did nothing
useful.

## Problem
In src/pages/Home/components/CTA.tsx, the button used SecondaryButton
with to="" — an empty target passed to react-router's NavLink, which
resolved to the current route instead of linking anywhere useful.

## Fix
SecondaryButton always renders react-router's NavLink internally, with
no support for target/rel props and no handling for external URLs.
Since NavLink isn't reliable for external links (client-side routing
tries to intercept them) and reliably opening a new tab is a stated
requirement, this replaces just this one instance with a plain <a>
tag pointing to the GitHub issues page:

- href="https://github.com/Open-Source-Kigali/osk-frontend/issues"
- target="_blank" + rel="noopener noreferrer" so it opens in a new
  tab safely
- className copied exactly from SecondaryButton's source, so the
  button's appearance (border, hover scale, colors) is unchanged

SecondaryButton itself is untouched — this fix is scoped to the one
broken instance rather than changing a shared component used
elsewhere in the app.

## Testing
Ran the app locally, clicked the button, and confirmed it opens the
GitHub issues page in a new tab. Verified visually that styling
matches the adjacent "Join the Community" button. Ran `npx tsc
--noEmit` with no errors.