### PR TITLE
fix: correct WhatsApp label in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -79,7 +79,7 @@ const socialLinks = [
   {
     icon: <FaWhatsapp size={18} />,
     href: "https://chat.whatsapp.com/GimdjJcYLyyG62zpgsI0zB",
-    label: "Discord",
+    label: "WhatsApp",
   },
   {
     icon: <Mail size={18} />,


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly in 1-3 sentences -->
It fixes the incorrect label for the WhatsApp social link in the footer component. It was originally using WhatsApp icon and URL but it was incorrectly labeled as Discord.

## Related issue

Closes #278 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [ ] No `console.log` statements left in the code

## Screenshots (if UI change)

--

## Notes for the reviewer

--