### PR TITLE
fix: correct .env copy command in README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm install
 ### 3️⃣ Create Environment Variables
 
 ```bash
-cp .env
+cp .env.example .env
 ```
 
 ### 4️⃣ Start Development Server


### PR DESCRIPTION
Fixes #282

Changed `cp .env` to `cp .env.example .env` in the README setup instructions.