### PR TITLE
Fix README environment setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm install
 ### 3️⃣ Create Environment Variables
 
 ```bash
-cp .env
+cp .env.example .env
 ```
 
 ### 4️⃣ Start Development Server


### PR DESCRIPTION
## Summary

This PR fixes the environment setup instruction in the README.

### Changes
- Updated the environment variable setup command from:
  ```bash
  cp .env
  ```
  to:
  ```bash
  cp .env.example .env
  ```
- This ensures new contributors copy the example environment file correctly during project setup.

Closes #282.