### PR TITLE
fix: correct Footer logo alt text

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,7 +101,7 @@ const Footer = () => {
             <NavLink to="/" className="inline-block mb-4">
               <img
                 src={whiteLogo}
-                alt="Open Source Kigali logo"
+                alt="Open Source Kigali Logo"
                 className=" w-24 md:w-32 "
               />
             </NavLink>


### PR DESCRIPTION
## Summary
Updates Footer logo alt text to `Open Source Kigali Logo` (issue #277 requested capitalization / typo fix).

Fixes #277

## Test plan
- [x] Only alt text changed in src/components/Footer.tsx