### PR TITLE
fix: correct Footer resource routes

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,8 +29,8 @@ const linkGroups: FooterLinkGroup[] = [
   {
     heading: "Resources",
     links: [
-      { label: "Blog", to: "/blog" },
-      { label: "Events", to: "/events" },
+      // Blog route does not exist yet — omit until the page ships.
+      { label: "Events", to: "/event" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Events link: `/events` → `/event`
- Remove Blog link (route does not exist yet)

Fixes #279

## Test plan
- [ ] Footer Events navigates to the Events page
- [ ] No 404 from Blog in the footer