### PR TITLE
fix(a11y): dynamic aria-label for mobile menu button

### DIFF
--- a/src/components/MainNavigation.tsx
+++ b/src/components/MainNavigation.tsx
@@ -96,7 +96,7 @@ const Navbar = () => {
         <button
           className="md:hidden z-50 p-1"
           onClick={() => setMobileOpen((o) => !o)}
-          aria-label="Toggle menu"
+          aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
         >
           {mobileOpen ? (
             <X className={`w-6 h-6 text-gray-900`} />


### PR DESCRIPTION
## Summary
Mobile menu button now uses:
- closed → `Open navigation menu`
- open → `Close navigation menu`

Fixes #254

## Test plan
- [ ] Toggle mobile menu — aria-label updates
- [ ] `npm run lint`