### PR TITLE
add typecheck-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",


### PR DESCRIPTION
## What does this PR do?

The PR adds a typecheck script to package.json using tsc --noEmit. This makes the npm run typecheck command available as documented in the README.

## Related issue

Closes #284 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [x] Other (describe below)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [x] No `console.log` statements left in the code

## Screenshots (if UI change)

N/A

## Notes for the reviewer

The change only adds the missing typecheck script to package.json to align the available scripts with the project's README.