### PR TITLE
Fix: standardized the heroSection padding match all the other sections

### DIFF
--- a/src/pages/Home/components/HeroSection.tsx
+++ b/src/pages/Home/components/HeroSection.tsx
@@ -17,7 +17,7 @@ const HeroSection = () => {
             <HeroSlideshow images={heroImages} />
 
 
-            <div className="z-10 h-full pt-28 md:pt-34 px-4 md:px-25 space-y-8">
+            <div className="z-10 h-full pt-28 md:pt-34 px-4 md:px-20 space-y-8">
                 <h1 className="text-3xl text-center sm:text-start sm:text-3xl md:text-4xl lg:text-6xl leading-snug text-white font-bold max-w-3xl">
                     Empowering Rwanda <br className="sm:hidden " />
                     to Build the{" "}


### PR DESCRIPTION
## What does this PR do?

This PR is standardizing the padding of the heroSection to match all the padding of the other sections

## Related issue

Closes #265 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [x] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [ ] No `console.log` statements left in the code

## Screenshots (if UI change)

<!-- Paste before/after screenshots here -->

## Notes for the reviewer

<!-- Anything you want the reviewer to pay attention to -->