### PR TITLE
fix: set document title to 'Page Not Found | Open Source Kigali' on error page

### DIFF
--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,23 +1,26 @@
-import { useRouteError, isRouteErrorResponse, NavLink } from "react-router"
+import { useEffect } from "react";
+import { useRouteError, isRouteErrorResponse, NavLink } from "react-router";
 
 const ErrorPage = () => {
-  const error = useRouteError()
+  const error = useRouteError();
 
-  let title = "Something went wrong"
-  let message = "An unexpected error occurred. Please try again."
+  let title = "Something went wrong";
+  let message = "An unexpected error occurred. Please try again.";
 
   if (isRouteErrorResponse(error)) {
     if (error.status === 404) {
-      title = "Page not found"
-      message = "The page you're looking for doesn't exist or has been moved."
+      title = "Page not found";
+      message = "The page you're looking for doesn't exist or has been moved.";
     } else {
-      title = `${error.status} ${error.statusText}`
-      message = error.data?.message ?? message
+      title = `${error.status} ${error.statusText}`;
+      message = error.data?.message ?? message;
     }
   } else if (error instanceof Error) {
-    message = error.message
+    message = error.message;
   }
-
+  useEffect(() => {
+    document.title = "Page Not Found | Open Source Kigali";
+  }, []);
   return (
     <main className="min-h-[70vh] flex items-center justify-center px-6">
       <div className="text-center max-w-md">
@@ -33,7 +36,7 @@ const ErrorPage = () => {
         </NavLink>
       </div>
     </main>
-  )
-}
+  );
+};
 
-export default ErrorPage
+export default ErrorPage;


### PR DESCRIPTION
## What does this PR do?
Added a useEffect hook in src/pages/ErrorPage.tsx to dynamically set document.title to "Page Not Found | Open Source Kigali" when the error component renders.

## Related issue

Closes #216 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor (no behaviour change)
- [ ] Style / UI improvement
- [ ] Other (describe below)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Tested locally in the browser
- [ ] New data is in `src/constants/`, not hardcoded in a component
- [x] No `console.log` statements left in the code

## Screenshots (if UI change)

<!-- Paste before/after screenshots here -->
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/ca710ddf-5e1d-494f-9f7c-378b8cc709af" />

## Notes for the reviewer

<!-- Anything you want the reviewer to pay attention to -->